### PR TITLE
Prevent Input Leakage From UI Searches

### DIFF
--- a/src/core/ui_manager.lua
+++ b/src/core/ui_manager.lua
@@ -60,6 +60,18 @@ UIManager.layerOrder = {
   "debug"
 }
 
+local function isTextInputFocused()
+    if UIManager.state.inventory.open and Inventory.isSearchInputActive and Inventory.isSearchInputActive() then
+        return true
+    end
+
+    if UIManager.state.docked.open and DockedUI.isSearchActive and DockedUI.isSearchActive() then
+        return true
+    end
+
+    return false
+end
+
 -- Modal state - when true, blocks input to lower layers
 UIManager.modalActive = false
 UIManager.modalComponent = nil
@@ -742,6 +754,8 @@ end
 
 -- Handle keyboard input for UI components
 function UIManager.keypressed(key, scancode, isrepeat)
+  local textInputFocused = isTextInputFocused()
+
   -- Check for global hotkeys first
   if key == "escape" then
     -- Priority order: escape menu > docked UI > other modals
@@ -776,14 +790,18 @@ function UIManager.keypressed(key, scancode, isrepeat)
     end
     return true
   elseif key == "i" then
-    UIManager.toggle("inventory")
-    return true
+    if not textInputFocused then
+      UIManager.toggle("inventory")
+      return true
+    end
   end
 
   -- Also accept TAB as inventory toggle at UI manager level so tab works regardless
   if key == "tab" then
-    UIManager.toggle("inventory")
-    return true
+    if not textInputFocused then
+      UIManager.toggle("inventory")
+      return true
+    end
   end
   
   -- Route to active components

--- a/src/ui/docked.lua
+++ b/src/ui/docked.lua
@@ -127,6 +127,10 @@ function DockedUI.isVisible()
   return DockedUI.visible
 end
 
+function DockedUI.isSearchActive()
+  return DockedUI.searchActive
+end
+
 -- Draw the docked window
 function DockedUI.draw(player)
     if not DockedUI.visible or not player or not player.docked then return end

--- a/src/ui/inventory.lua
+++ b/src/ui/inventory.lua
@@ -67,6 +67,10 @@ function Inventory.clearSearchFocus()
   setSearchActive(false)
 end
 
+function Inventory.isSearchInputActive()
+  return Inventory._searchInputActive
+end
+
 function Inventory.init()
     Inventory.window = Window.new({
         title = "Inventory",


### PR DESCRIPTION
## Summary
- add shared helper that reports when UI search fields have focus so gameplay input is skipped
- block global hotkeys in UI manager while docked or inventory searches are active
- expose search-focus accessors on the docked and inventory panels for reuse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6c22226c48322a4ba724234014c33