### PR TITLE
Restyle Turret Icons With Sci-Fi Silhouettes

### DIFF
--- a/content/turrets/basic_gun.lua
+++ b/content/turrets/basic_gun.lua
@@ -8,15 +8,18 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Gun barrel
-      { type = "rectangle", mode = "fill", color = {0.7, 0.7, 0.7, 1}, x = 8, y = 12, w = 16, h = 8, rx = 1 },
-      -- Gun housing
-      { type = "rectangle", mode = "fill", color = {0.5, 0.5, 0.5, 1}, x = 4, y = 8, w = 24, h = 16, rx = 2 },
-      -- Muzzle
-      { type = "rectangle", mode = "fill", color = {0.9, 0.8, 0.6, 1}, x = 24, y = 14, w = 4, h = 4, rx = 0.5 },
-      -- Details
-      { type = "rectangle", mode = "fill", color = {0.3, 0.3, 0.3, 1}, x = 6, y = 10, w = 3, h = 2, rx = 0.5 },
-      { type = "rectangle", mode = "fill", color = {0.3, 0.3, 0.3, 1}, x = 23, y = 10, w = 3, h = 2, rx = 0.5 },
+      -- Faceted chassis panels
+      { type = "polygon", mode = "fill", color = {0.10, 0.14, 0.20, 1}, points = {4, 12, 8, 6, 24, 6, 28, 12, 24, 20, 8, 20} },
+      { type = "polygon", mode = "fill", color = {0.22, 0.30, 0.38, 1}, points = {6, 13, 10, 9, 22, 9, 26, 13, 22, 19, 10, 19} },
+      -- Magnetic rail shrouds
+      { type = "rectangle", mode = "fill", color = {0.00, 0.65, 0.95, 0.85}, x = 9, y = 12, w = 14, h = 3, rx = 1 },
+      { type = "rectangle", mode = "fill", color = {0.00, 0.65, 0.95, 0.7}, x = 9, y = 18, w = 14, h = 2, rx = 1 },
+      -- Barrel core and muzzle bloom
+      { type = "rectangle", mode = "fill", color = {0.55, 0.80, 1.00, 1}, x = 14, y = 6, w = 4, h = 13, rx = 1 },
+      { type = "circle", mode = "fill", color = {0.95, 0.98, 1.00, 0.9}, x = 16, y = 6, r = 3 },
+      -- Targeting lights
+      { type = "circle", mode = "fill", color = {0.00, 0.85, 1.00, 0.85}, x = 11, y = 15, r = 1.2 },
+      { type = "circle", mode = "fill", color = {0.00, 0.85, 1.00, 0.85}, x = 21, y = 15, r = 1.2 },
     }
   },
   spread = { minDeg = 0.15, maxDeg = 1.2, decay = 600 }, -- Much tighter spread for excellent accuracy

--- a/content/turrets/boss_cone_gun.lua
+++ b/content/turrets/boss_cone_gun.lua
@@ -7,9 +7,21 @@ return {
   icon = {
     size = 32,
     shapes = {
-      { type = "rectangle", mode = "fill", color = {0.4, 0.4, 0.45, 1}, x = 6, y = 10, w = 22, h = 12, rx = 2 },
-      { type = "rectangle", mode = "fill", color = {0.85, 0.4, 0.2, 1}, x = 24, y = 13, w = 6, h = 6, rx = 1 },
-      { type = "polygon", mode = "line", color = {1.0, 0.6, 0.2, 0.9}, points = { 6,16,  18,10,  28,16,  18,22 } },
+      -- Hardened emitter wedge
+      { type = "polygon", mode = "fill", color = {0.10, 0.10, 0.18, 1}, points = {6, 26, 10, 12, 22, 12, 26, 26, 16, 30} },
+      { type = "polygon", mode = "fill", color = {0.28, 0.18, 0.36, 1}, points = {8, 22, 12, 14, 20, 14, 24, 22, 16, 26} },
+      -- Triple plasma barrels
+      { type = "circle", mode = "fill", color = {1.00, 0.58, 0.28, 1}, x = 12, y = 12, r = 2.2 },
+      { type = "circle", mode = "fill", color = {1.00, 0.66, 0.32, 1}, x = 16, y = 11, r = 2.5 },
+      { type = "circle", mode = "fill", color = {1.00, 0.58, 0.28, 1}, x = 20, y = 12, r = 2.2 },
+      { type = "rectangle", mode = "fill", color = {0.55, 0.18, 0.30, 1}, x = 10, y = 10, w = 12, h = 4, rx = 1.5 },
+      -- Cone of fire reticles
+      { type = "polygon", mode = "line", color = {1.00, 0.70, 0.30, 0.9}, points = {8, 18, 16, 8, 24, 18, 16, 24}, lineWidth = 1.6 },
+      { type = "polygon", mode = "line", color = {1.00, 0.45, 0.20, 0.7}, points = {10, 19, 16, 11, 22, 19, 16, 23}, lineWidth = 1.2 },
+      -- Core glow
+      { type = "circle", mode = "fill", color = {0.95, 0.78, 0.32, 0.85}, x = 16, y = 19, r = 2.3 },
+      -- Thruster vent accent
+      { type = "rectangle", mode = "fill", color = {0.10, 0.60, 0.90, 0.75}, x = 12, y = 22, w = 8, h = 2, rx = 1 },
     }
   },
   spread = { minDeg = 0.0, maxDeg = 0.0, decay = 800 },
@@ -35,3 +47,4 @@ return {
   -- Firing mode: "manual" or "automatic"
   fireMode = "manual"
 }
+

--- a/content/turrets/giant_cannon.lua
+++ b/content/turrets/giant_cannon.lua
@@ -7,15 +7,21 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Giant gun barrel
-      { type = "rectangle", mode = "fill", color = {0.7, 0.7, 0.7, 1}, x = 6, y = 10, w = 20, h = 12, rx = 2 },
-      -- Gun housing
-      { type = "rectangle", mode = "fill", color = {0.5, 0.5, 0.5, 1}, x = 2, y = 6, w = 28, h = 20, rx = 3 },
-      -- Muzzle
-      { type = "rectangle", mode = "fill", color = {0.9, 0.8, 0.6, 1}, x = 24, y = 12, w = 6, h = 8, rx = 1 },
-      -- Details
-      { type = "rectangle", mode = "fill", color = {0.3, 0.3, 0.3, 1}, x = 4, y = 8, w = 4, h = 3, rx = 0.5 },
-      { type = "rectangle", mode = "fill", color = {0.3, 0.3, 0.3, 1}, x = 24, y = 8, w = 4, h = 3, rx = 0.5 },
+      -- Massive armored cradle
+      { type = "polygon", mode = "fill", color = {0.08, 0.11, 0.16, 1}, points = {4, 24, 7, 10, 25, 10, 28, 24, 16, 30} },
+      { type = "polygon", mode = "fill", color = {0.18, 0.22, 0.30, 1}, points = {6, 20, 10, 12, 22, 12, 26, 20, 16, 26} },
+      -- Reinforced rails
+      { type = "rectangle", mode = "fill", color = {0.14, 0.28, 0.42, 1}, x = 9, y = 14, w = 14, h = 4, rx = 1.2 },
+      { type = "rectangle", mode = "fill", color = {0.14, 0.28, 0.42, 1}, x = 11, y = 19, w = 10, h = 3, rx = 1.2 },
+      -- Cannon spine
+      { type = "rectangle", mode = "fill", color = {0.30, 0.40, 0.50, 1}, x = 13, y = 6, w = 6, h = 16, rx = 2 },
+      { type = "rectangle", mode = "fill", color = {0.60, 0.70, 0.80, 1}, x = 14, y = 4, w = 4, h = 18, rx = 2 },
+      -- Muzzle coil and bloom
+      { type = "circle", mode = "fill", color = {0.95, 0.60, 0.25, 0.95}, x = 16, y = 4, r = 3.2 },
+      { type = "circle", mode = "line", color = {1.00, 0.80, 0.40, 0.8}, x = 16, y = 4, r = 4.2, lineWidth = 1.5 },
+      -- Side capacitors
+      { type = "circle", mode = "fill", color = {0.00, 0.70, 0.95, 0.75}, x = 10, y = 18, r = 1.4 },
+      { type = "circle", mode = "fill", color = {0.00, 0.70, 0.95, 0.75}, x = 22, y = 18, r = 1.4 },
     }
   },
   spread = { minDeg = 0.1, maxDeg = 1.0, decay = 600 },

--- a/content/turrets/laser_mk1.lua
+++ b/content/turrets/laser_mk1.lua
@@ -8,15 +8,21 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Laser emitter housing
-      { type = "rectangle", mode = "fill", color = {0.3, 0.8, 1.0, 1}, x = 4, y = 8, w = 24, h = 16, rx = 2 },
-      -- Lens
-      { type = "circle", mode = "fill", color = {0.5, 0.9, 1.0, 1}, x = 16, y = 16, r = 3 },
-      -- Beam
-      { type = "rectangle", mode = "fill", color = {0.7, 1.0, 1.0, 0.8}, x = 15, y = 4, w = 2, h = 12 },
-      -- Energy arcs
-      { type = "arc", mode = "line", color = {0.4, 0.9, 1.0, 0.6}, x = 16, y = 16, r = 5, angle1 = -0.3, angle2 = 0.3, segments = 8 },
-      { type = "arc", mode = "line", color = {0.4, 0.9, 1.0, 0.6}, x = 16, y = 16, r = 7, angle1 = -0.2, angle2 = 0.2, segments = 6 },
+      -- Angular emitter frame
+      { type = "polygon", mode = "fill", color = {0.08, 0.12, 0.18, 1}, points = {6, 22, 9, 10, 23, 10, 26, 22, 16, 28} },
+      { type = "polygon", mode = "fill", color = {0.16, 0.22, 0.30, 1}, points = {8, 18, 11, 12, 21, 12, 24, 18, 16, 24} },
+      -- Energy conduits
+      { type = "rectangle", mode = "fill", color = {0.05, 0.35, 0.55, 1}, x = 9, y = 14, w = 14, h = 3, rx = 1 },
+      { type = "rectangle", mode = "fill", color = {0.05, 0.35, 0.55, 1}, x = 11, y = 18, w = 10, h = 2, rx = 1 },
+      -- Focused lens cluster
+      { type = "circle", mode = "fill", color = {0.05, 0.22, 0.32, 1}, x = 16, y = 8, r = 5 },
+      { type = "circle", mode = "fill", color = {0.15, 0.70, 0.95, 1}, x = 16, y = 8, r = 3.2 },
+      { type = "circle", mode = "fill", color = {0.70, 1.00, 1.00, 0.9}, x = 16, y = 8, r = 1.8 },
+      -- Projection spike
+      { type = "polygon", mode = "fill", color = {0.55, 0.95, 1.00, 0.9}, points = {14, 2, 18, 2, 20, 8, 12, 8} },
+      -- Containment rings
+      { type = "arc", mode = "line", color = {0.15, 0.75, 1.00, 0.6}, x = 16, y = 8, r = 7, angle1 = -0.7, angle2 = 0.7, segments = 14, lineWidth = 1.5 },
+      { type = "arc", mode = "line", color = {0.25, 0.85, 1.00, 0.45}, x = 16, y = 8, r = 9, angle1 = -0.5, angle2 = 0.5, segments = 12, lineWidth = 1 },
     }
   },
   -- Visuals: blue combat beam, crisp shield arcs

--- a/content/turrets/lightning_turret.lua
+++ b/content/turrets/lightning_turret.lua
@@ -8,7 +8,20 @@ return {
   icon = {
     size = 32,
     shapes = {
-      { type = "rectangle", mode = "fill", color = {0.7, 0.7, 0.7, 1}, x = 8, y = 12, w = 16, h = 8, rx = 1 },
+      -- Suspended coil cradle
+      { type = "polygon", mode = "fill", color = {0.08, 0.10, 0.18, 1}, points = {6, 22, 10, 12, 22, 12, 26, 22, 16, 28} },
+      { type = "polygon", mode = "fill", color = {0.16, 0.20, 0.28, 1}, points = {8, 20, 12, 14, 20, 14, 24, 20, 16, 24} },
+      -- Electromagnetic containment rings
+      { type = "circle", mode = "line", color = {0.35, 0.80, 1.00, 0.7}, x = 16, y = 16, r = 6, lineWidth = 2 },
+      { type = "circle", mode = "line", color = {0.20, 0.65, 1.00, 0.45}, x = 16, y = 16, r = 8, lineWidth = 1.5 },
+      -- Charged capacitor core
+      { type = "circle", mode = "fill", color = {0.05, 0.18, 0.30, 1}, x = 16, y = 16, r = 4 },
+      { type = "circle", mode = "fill", color = {0.45, 0.90, 1.00, 1}, x = 16, y = 16, r = 2.6 },
+      -- Lightning discharge
+      { type = "polygon", mode = "fill", color = {0.70, 0.95, 1.00, 1}, points = {14, 4, 19, 6, 16, 10, 21, 12, 12, 22, 15, 14, 11, 12} },
+      -- Spark accents
+      { type = "circle", mode = "fill", color = {0.55, 0.95, 1.00, 0.8}, x = 11, y = 18, r = 1.2 },
+      { type = "circle", mode = "fill", color = {0.55, 0.95, 1.00, 0.8}, x = 21, y = 18, r = 1.2 },
     }
   },
   tracer = { color = {0.5, 0.8, 1.0, 1.0}, width = 2.0, coreRadius = 1 },

--- a/content/turrets/mining_laser.lua
+++ b/content/turrets/mining_laser.lua
@@ -8,18 +8,24 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Mining laser housing
-      { type = "rectangle", mode = "fill", color = {0.6, 0.4, 0.2, 1}, x = 6, y = 10, w = 20, h = 12, rx = 1 },
-      -- Lens
-      { type = "circle", mode = "fill", color = {0.8, 0.6, 0.3, 1}, x = 16, y = 16, r = 3 },
+      -- Articulated mining frame
+      { type = "polygon", mode = "fill", color = {0.10, 0.11, 0.18, 1}, points = {6, 24, 9, 10, 23, 10, 26, 24, 16, 30} },
+      { type = "polygon", mode = "fill", color = {0.28, 0.20, 0.12, 1}, points = {8, 20, 12, 12, 20, 12, 24, 20, 16, 26} },
+      -- Power conduits
+      { type = "rectangle", mode = "fill", color = {0.72, 0.48, 0.22, 1}, x = 10, y = 14, w = 12, h = 3, rx = 1 },
+      { type = "rectangle", mode = "fill", color = {0.90, 0.64, 0.30, 1}, x = 12, y = 18, w = 8, h = 2, rx = 1 },
+      -- Focused emitter core
+      { type = "circle", mode = "fill", color = {0.25, 0.16, 0.10, 1}, x = 16, y = 12, r = 3 },
+      { type = "circle", mode = "fill", color = {1.00, 0.78, 0.36, 0.9}, x = 16, y = 12, r = 1.8 },
       -- Mining beam
-      { type = "rectangle", mode = "fill", color = {1.0, 0.8, 0.4, 0.7}, x = 15, y = 4, w = 2, h = 12 },
-      -- Mining particles
-      { type = "circle", mode = "fill", color = {1.0, 0.9, 0.5, 0.5}, x = 16, y = 8, r = 1 },
-      { type = "circle", mode = "fill", color = {1.0, 0.9, 0.5, 0.5}, x = 14, y = 12, r = 1 },
-      { type = "circle", mode = "fill", color = {1.0, 0.9, 0.5, 0.5}, x = 18, y = 10, r = 1 },
-      -- Drill bit
-      { type = "polygon", mode = "fill", color = {0.4, 0.4, 0.4, 1}, points = {14, 22, 16, 26, 18, 22} },
+      { type = "polygon", mode = "fill", color = {1.00, 0.86, 0.42, 0.75}, points = {14, 13, 18, 13, 21, 28, 11, 28} },
+      { type = "polygon", mode = "fill", color = {1.00, 0.95, 0.60, 0.8}, points = {15, 13, 17, 13, 19, 28, 13, 28} },
+      -- Target crystal
+      { type = "polygon", mode = "fill", color = {0.55, 0.80, 1.00, 0.9}, points = {13, 26, 16, 30, 19, 26, 16, 22} },
+      { type = "polygon", mode = "line", color = {0.80, 0.95, 1.00, 0.7}, points = {13, 26, 16, 30, 19, 26, 16, 22}, lineWidth = 1 },
+      -- Sensor lights
+      { type = "circle", mode = "fill", color = {1.00, 0.80, 0.35, 0.85}, x = 12, y = 18, r = 1.1 },
+      { type = "circle", mode = "fill", color = {1.00, 0.80, 0.35, 0.85}, x = 20, y = 18, r = 1.1 },
     }
   },
   -- Yellow mining beam
@@ -48,3 +54,4 @@ return {
   -- Firing mode: "manual" or "automatic"
   fireMode = "manual" -- Mining lasers should be manually controlled
 }
+

--- a/content/turrets/rocket_mk1.lua
+++ b/content/turrets/rocket_mk1.lua
@@ -8,19 +8,23 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Rocket launcher housing
-      { type = "rectangle", mode = "fill", color = {0.4, 0.4, 0.4, 1}, x = 4, y = 12, w = 24, h = 8, rx = 1 },
-      -- Rocket
-      { type = "rectangle", mode = "fill", color = {0.8, 0.3, 0.1, 1}, x = 12, y = 6, w = 8, h = 16 },
-      -- Rocket nose
-      { type = "polygon", mode = "fill", color = {0.9, 0.4, 0.2, 1}, points = {12, 6, 16, 2, 20, 6} },
-      -- Fins
-      { type = "rectangle", mode = "fill", color = {0.6, 0.6, 0.6, 1}, x = 10, y = 18, w = 2, h = 4 },
-      { type = "rectangle", mode = "fill", color = {0.6, 0.6, 0.6, 1}, x = 20, y = 18, w = 2, h = 4 },
-      -- Exhaust
-      { type = "rectangle", mode = "fill", color = {1.0, 0.8, 0.3, 0.8}, x = 14, y = 22, w = 4, h = 6 },
-      -- Launch rails
-      { type = "rectangle", mode = "fill", color = {0.3, 0.3, 0.3, 1}, x = 2, y = 14, w = 28, h = 2 },
+      -- Reinforced launcher cradle
+      { type = "polygon", mode = "fill", color = {0.10, 0.12, 0.18, 1}, points = {5, 26, 8, 10, 24, 10, 27, 26, 16, 30} },
+      { type = "polygon", mode = "fill", color = {0.18, 0.22, 0.30, 1}, points = {8, 22, 10, 14, 22, 14, 24, 22, 16, 26} },
+      -- Launch tubes
+      { type = "rectangle", mode = "fill", color = {0.20, 0.36, 0.52, 1}, x = 9, y = 14, w = 6, h = 8, rx = 1 },
+      { type = "rectangle", mode = "fill", color = {0.20, 0.36, 0.52, 1}, x = 17, y = 14, w = 6, h = 8, rx = 1 },
+      -- Rocket chassis
+      { type = "polygon", mode = "fill", color = {0.85, 0.32, 0.25, 1}, points = {16, 4, 20, 12, 12, 12} },
+      { type = "polygon", mode = "fill", color = {1.00, 0.52, 0.30, 0.9}, points = {16, 5, 19, 11, 13, 11} },
+      -- Guidance fins
+      { type = "polygon", mode = "fill", color = {0.70, 0.76, 0.82, 1}, points = {12, 12, 10, 16, 14, 16} },
+      { type = "polygon", mode = "fill", color = {0.70, 0.76, 0.82, 1}, points = {20, 12, 18, 16, 22, 16} },
+      -- Exhaust plumes
+      { type = "polygon", mode = "fill", color = {1.00, 0.70, 0.25, 0.85}, points = {14, 16, 18, 16, 21, 24, 11, 24} },
+      { type = "polygon", mode = "fill", color = {1.00, 0.45, 0.15, 0.8}, points = {14, 18, 18, 18, 19, 24, 13, 24} },
+      -- Targeting strip
+      { type = "rectangle", mode = "fill", color = {0.00, 0.75, 0.95, 0.8}, x = 10, y = 20, w = 12, h = 2, rx = 1 },
     }
   },
   -- Visuals: warm orange rocket + exhaust

--- a/content/turrets/salvaging_laser.lua
+++ b/content/turrets/salvaging_laser.lua
@@ -8,19 +8,24 @@ return {
   icon = {
     size = 32,
     shapes = {
-      -- Salvaging laser housing
-      { type = "rectangle", mode = "fill", color = {0.2, 0.5, 0.2, 1}, x = 6, y = 10, w = 20, h = 12, rx = 1 },
-      -- Lens
-      { type = "circle", mode = "fill", color = {0.4, 0.8, 0.4, 1}, x = 16, y = 16, r = 3 },
-      -- Salvaging beam
-      { type = "rectangle", mode = "fill", color = {0.5, 1.0, 0.5, 0.7}, x = 15, y = 4, w = 2, h = 12 },
-      -- Salvage particles
-      { type = "circle", mode = "fill", color = {0.6, 1.0, 0.6, 0.5}, x = 16, y = 8, r = 1 },
-      { type = "circle", mode = "fill", color = {0.6, 1.0, 0.6, 0.5}, x = 14, y = 12, r = 1 },
-      { type = "circle", mode = "fill", color = {0.6, 1.0, 0.6, 0.5}, x = 18, y = 10, r = 1 },
-      -- Magnet attachment
-      { type = "circle", mode = "fill", color = {0.3, 0.6, 0.3, 1}, x = 16, y = 22, r = 4 },
-      { type = "rectangle", mode = "fill", color = {0.4, 0.7, 0.4, 1}, x = 14, y = 20, w = 4, h = 2 },
+      -- Adaptive salvage frame
+      { type = "polygon", mode = "fill", color = {0.08, 0.12, 0.10, 1}, points = {6, 24, 9, 10, 23, 10, 26, 24, 16, 30} },
+      { type = "polygon", mode = "fill", color = {0.16, 0.36, 0.20, 1}, points = {8, 20, 12, 12, 20, 12, 24, 20, 16, 26} },
+      -- Stabilized emitter core
+      { type = "circle", mode = "fill", color = {0.12, 0.35, 0.18, 1}, x = 16, y = 12, r = 3.2 },
+      { type = "circle", mode = "fill", color = {0.40, 0.85, 0.45, 0.95}, x = 16, y = 12, r = 2 },
+      -- Salvage beam
+      { type = "polygon", mode = "fill", color = {0.45, 1.00, 0.60, 0.75}, points = {14, 13, 18, 13, 22, 28, 10, 28} },
+      { type = "polygon", mode = "fill", color = {0.70, 1.00, 0.80, 0.85}, points = {15, 13, 17, 13, 20, 28, 12, 28} },
+      -- Magnetized recovery claws
+      { type = "polygon", mode = "fill", color = {0.05, 0.45, 0.28, 1}, points = {10, 20, 6, 24, 10, 24, 12, 22} },
+      { type = "polygon", mode = "fill", color = {0.05, 0.45, 0.28, 1}, points = {22, 20, 26, 24, 22, 24, 20, 22} },
+      -- Salvaged fragment
+      { type = "polygon", mode = "fill", color = {0.65, 0.82, 0.65, 0.9}, points = {13, 26, 16, 29, 19, 26, 16, 23} },
+      { type = "polygon", mode = "line", color = {0.80, 1.00, 0.80, 0.65}, points = {13, 26, 16, 29, 19, 26, 16, 23}, lineWidth = 1 },
+      -- Scanner lights
+      { type = "circle", mode = "fill", color = {0.40, 1.00, 0.60, 0.9}, x = 12, y = 18, r = 1.1 },
+      { type = "circle", mode = "fill", color = {0.40, 1.00, 0.60, 0.9}, x = 20, y = 18, r = 1.1 },
     }
   },
   -- Visuals: green salvaging beam
@@ -45,3 +50,4 @@ return {
   -- Firing mode: "manual" or "automatic"
   fireMode = "manual" -- Salvaging lasers should be manually controlled
 }
+


### PR DESCRIPTION
## Summary
- redesign turret icon definitions with layered sci-fi silhouettes for guns, lasers, rockets, and specialty tools
- add energy glows, containment rings, and salvage details so each icon reflects its turret role

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6dbd2f4a88322b8bc239a96755b47