### PR TITLE
Make Utility Lasers Continuous Damage Streams

### DIFF
--- a/content/turrets/mining_laser.lua
+++ b/content/turrets/mining_laser.lua
@@ -37,18 +37,18 @@ return {
       particles = {1.0, 0.8, 0.2, 0.7} -- Bright particles
     },
   },
-  -- Pulsed mining beam, 3 second cycles
+  -- Continuous mining beam, tuned for a gentle extraction rate
   optimal = 850, falloff = 250,
   damageMin = 1, damageMax = 2, -- Mining damage per pulse
-  cycle = 3.0, -- 3 second cycles for pulsing behavior
-  capCost = 25, -- Energy cost per pulse
+  cycle = 3.0, -- Seconds required to deal miningPower damage (controls DPS)
+  capCost = 25, -- Energy cost budget per cycle window
   spread = { minDeg = 0.05, maxDeg = 0.1, decay = 1000 }, -- Very precise for mining
-  miningPower = 2.5, -- Mining damage per pulse
-  beamDuration = 0.2, -- Visible beam duration per pulse
-  -- Heat management for pulsed beam
+  miningPower = 2.5, -- Total mining damage applied across each cycle window
+  beamDuration = 0.2, -- Legacy rendering hint for beam visuals
+  -- Heat management for continuous beam
   maxHeat = 20.0, -- Higher max heat for sustained use
-  heatPerShot = 5.0, -- Heat per pulse
-  cooldownRate = 10.0, -- Fast cooling between pulses
+  heatPerShot = 5.0, -- Heat generated across each cycle window
+  cooldownRate = 10.0, -- Fast cooling between pulses/pauses
   overheatCooldown = 5.0, -- Fixed cooldown window after overheating
 
   -- Firing mode: "manual" or "automatic"

--- a/content/turrets/salvaging_laser.lua
+++ b/content/turrets/salvaging_laser.lua
@@ -33,18 +33,18 @@ return {
   impact = {
     wreckage = { spark = {0.3, 1.0, 0.3, 0.8}, ring = {0.2, 0.8, 0.2, 0.6} },
   },
-  -- Pulsed salvaging beam, 3 second cycles
+  -- Continuous salvaging beam, tuned for gentle stripping of wreckage
   optimal = 850, falloff = 250,
   damageMin = 1, damageMax = 2, -- Salvaging damage per pulse
-  cycle = 3.0, -- 3 second cycles for pulsing behavior
-  capCost = 20, -- Energy cost per pulse
+  cycle = 3.0, -- Seconds required to apply salvagePower worth of extraction
+  capCost = 20, -- Energy cost budget per cycle window
   spread = { minDeg = 0.05, maxDeg = 0.1, decay = 1000 }, -- Very precise for salvaging
-  salvagePower = 1, -- Salvaging damage per pulse
-  beamDuration = 0.3, -- Visible beam duration per pulse
-  -- Heat management for pulsed beam
+  salvagePower = 1, -- Total salvage progress applied across each cycle window
+  beamDuration = 0.3, -- Legacy rendering hint for beam visuals
+  -- Heat management for continuous beam
   maxHeat = 15.0, -- Higher max heat for sustained use
-  heatPerShot = 3.0, -- Heat per pulse
-  cooldownRate = 8.0, -- Fast cooling between pulses
+  heatPerShot = 3.0, -- Heat generated across each cycle window
+  cooldownRate = 8.0, -- Fast cooling between pulses/pauses
   overheatCooldown = 5.0, -- Fixed cooldown window after overheating
 
   -- Firing mode: "manual" or "automatic"

--- a/src/systems/turret/core.lua
+++ b/src/systems/turret/core.lua
@@ -186,8 +186,16 @@ function Turret:update(dt, target, locked, world)
             UtilityBeams.updateSalvagingLaser(self, dt, target, locked, world)
         end
 
-        -- Set cooldown for next shot
-        self.cooldown = effectiveCycle
+        local overrideCooldown = self.cooldownOverride
+        self.cooldownOverride = nil
+
+        if overrideCooldown ~= nil then
+            self.cooldown = overrideCooldown
+        else
+            -- Set cooldown for next shot
+            self.cooldown = effectiveCycle
+        end
+
         Log.debug("Turret:update - Cooldown set to: " .. tostring(self.cooldown) .. " for turret: " .. tostring(self.id))
     end
 


### PR DESCRIPTION
## Summary
- convert mining and salvaging beams into continuous hitscan updates that tick damage each frame while playing effects at a throttled cadence
- track salvage payout fractions so wreckage yields the correct total while the beam streams
- let utility weapons override turret cooldowns and update turret data to reflect the continuous behavior

## Testing
- Not run (not requested)
- Manual QA (not run): Launch the game, equip a mining or salvaging laser, hold the fire hotkey, and confirm the beam stays visible while resources tick down continuously.

------
https://chatgpt.com/codex/tasks/task_b_68d92d0a5c588322980279198385f689

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert mining and salvaging lasers to continuous hitscan beams with per-frame damage, salvage yield tracking, throttled effects, and a turret cooldown override.
> 
> - **Systems (utility beams)**:
>   - **Continuous beams**: Rework `UtilityBeams.updateMiningLaser` and `UtilityBeams.updateSalvagingLaser` to apply damage each frame (`power / cycle * dt`), keep beams active, and throttle impact VFX via `IMPACT_INTERVAL`.
>   - **Heat + cooldown**: Apply heat per second and set `turret.cooldownOverride = 0` while streaming.
>   - **Salvage payouts**: Track fractional progress in `applySalvageDamage`, spawn pickups incrementally via `spawnSalvagePickup`, and drop remaining on completion; function now returns whether any salvage was removed.
>   - **Beam state**: Maintain `beamActive`, endpoints, and target each update; start sound once per activation.
>   - **Hitscan helpers**: Use shared `CollisionHelpers` (remove redundant requires).
> - **Core turret**:
>   - Add `cooldownOverride` handling in `Turret:update` to allow utility beams to bypass the normal cycle while firing.
> - **Content (turrets)**:
>   - Update `content/turrets/mining_laser.lua` and `content/turrets/salvaging_laser.lua` docs/semantics to reflect continuous operation (cycle as window, power as total per cycle, heat per cycle), keeping numeric values the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf9ee8de89502eeec12a2adc1c290a0b557f8466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->