### PR TITLE
Add 25 Specialized Turret Definitions

### DIFF
--- a/content/projectiles/arc_dart.lua
+++ b/content/projectiles/arc_dart.lua
@@ -1,0 +1,27 @@
+return {
+    id = "arc_dart",
+    name = "Arc Dart",
+    class = "Projectile",
+    physics = {
+        speed = 4800,
+        drag = 0.03,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "spark",
+            radius = 2.0,
+            color = {0.55, 0.95, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 3.8,
+        chainChance = 0.6,
+        chainRange = 280,
+        maxChains = 4,
+        chainDamageFalloff = 0.7,
+    },
+    timed_life = {
+        duration = 2.5,
+    }
+}

--- a/content/projectiles/breach_round.lua
+++ b/content/projectiles/breach_round.lua
@@ -1,0 +1,24 @@
+return {
+    id = "breach_round",
+    name = "Breach Round",
+    class = "Projectile",
+    physics = {
+        speed = 5600,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "slug",
+            radius = 2.4,
+            color = {1.00, 0.55, 0.35, 0.9},
+        }
+    },
+    damage = {
+        value = 5.8,
+        subsystemDamage = 1.5,
+    },
+    timed_life = {
+        duration = 3.0,
+    }
+}

--- a/content/projectiles/cluster_warhead.lua
+++ b/content/projectiles/cluster_warhead.lua
@@ -1,0 +1,25 @@
+return {
+    id = "cluster_warhead",
+    name = "Cluster Warhead",
+    class = "Projectile",
+    physics = {
+        speed = 700,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "missile",
+            radius = 4.0,
+            color = {1.00, 0.50, 0.20, 0.9},
+        }
+    },
+    damage = {
+        value = 5.0,
+        bomblets = 6,
+        splash = 90,
+    },
+    timed_life = {
+        duration = 4.5,
+    }
+}

--- a/content/projectiles/corrosion_stream.lua
+++ b/content/projectiles/corrosion_stream.lua
@@ -1,0 +1,24 @@
+return {
+    id = "corrosion_stream",
+    name = "Corrosion Stream",
+    class = "Projectile",
+    physics = {
+        speed = 4200,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "beam",
+            radius = 1.7,
+            color = {0.75, 0.95, 0.45, 0.9},
+        }
+    },
+    damage = {
+        value = 2.8,
+        armorCorrosion = { multiplier = 0.7, duration = 3.0 },
+    },
+    timed_life = {
+        duration = 2.0,
+    }
+}

--- a/content/projectiles/cryo_beam.lua
+++ b/content/projectiles/cryo_beam.lua
@@ -1,0 +1,24 @@
+return {
+    id = "cryo_beam",
+    name = "Cryo Beam",
+    class = "Projectile",
+    physics = {
+        speed = 5000,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "beam",
+            radius = 1.8,
+            color = {0.55, 0.90, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 2.6,
+        slowEffect = { multiplier = 0.6, duration = 2.5 },
+    },
+    timed_life = {
+        duration = 2.2,
+    }
+}

--- a/content/projectiles/disruptor_wave.lua
+++ b/content/projectiles/disruptor_wave.lua
@@ -1,0 +1,24 @@
+return {
+    id = "disruptor_wave",
+    name = "Disruptor Wave",
+    class = "Projectile",
+    physics = {
+        speed = 5400,
+        drag = 0.02,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "wave",
+            radius = 2.6,
+            color = {0.45, 0.95, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 4.2,
+        shieldBreaker = 1.6,
+    },
+    timed_life = {
+        duration = 3.0,
+    }
+}

--- a/content/projectiles/emp_pulse.lua
+++ b/content/projectiles/emp_pulse.lua
@@ -1,0 +1,24 @@
+return {
+    id = "emp_pulse",
+    name = "EMP Pulse",
+    class = "Projectile",
+    physics = {
+        speed = 3200,
+        drag = 0.02,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "pulse",
+            radius = 3.0,
+            color = {0.35, 0.90, 1.00, 0.85},
+        }
+    },
+    damage = {
+        value = 1.8,
+        empStrength = { shield = 2.2, systems = 1.6, duration = 3.5 },
+    },
+    timed_life = {
+        duration = 3.2,
+    }
+}

--- a/content/projectiles/flak_shard.lua
+++ b/content/projectiles/flak_shard.lua
@@ -1,0 +1,24 @@
+return {
+    id = "flak_shard",
+    name = "Flak Shard",
+    class = "Projectile",
+    physics = {
+        speed = 3200,
+        drag = 0.15,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "fragment",
+            radius = 2.0,
+            color = {1.00, 0.75, 0.35, 0.9},
+        }
+    },
+    damage = {
+        value = 3,
+        splash = 80,
+    },
+    timed_life = {
+        duration = 1.8,
+    }
+}

--- a/content/projectiles/fusion_pulse_beam.lua
+++ b/content/projectiles/fusion_pulse_beam.lua
@@ -1,0 +1,23 @@
+return {
+    id = "fusion_pulse_beam",
+    name = "Fusion Pulse Beam",
+    class = "Projectile",
+    physics = {
+        speed = 5000,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "beam",
+            radius = 2.0,
+            color = {1.00, 0.60, 0.20, 0.95},
+        }
+    },
+    damage = {
+        value = 4.8,
+    },
+    timed_life = {
+        duration = 2.8,
+    }
+}

--- a/content/projectiles/gauss_slug.lua
+++ b/content/projectiles/gauss_slug.lua
@@ -1,0 +1,23 @@
+return {
+    id = "gauss_slug",
+    name = "Gauss Slug",
+    class = "Projectile",
+    physics = {
+        speed = 6000,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "slug",
+            radius = 3.2,
+            color = {0.65, 0.85, 1.00, 1.0},
+        }
+    },
+    damage = {
+        value = 6,
+    },
+    timed_life = {
+        duration = 3.5,
+    }
+}

--- a/content/projectiles/graviton_orb.lua
+++ b/content/projectiles/graviton_orb.lua
@@ -1,0 +1,24 @@
+return {
+    id = "graviton_orb",
+    name = "Graviton Orb",
+    class = "Projectile",
+    physics = {
+        speed = 2600,
+        drag = 0.04,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "orb",
+            radius = 3.0,
+            color = {0.65, 0.55, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 3.8,
+        gravityWell = { radius = 180, force = 140, duration = 2.5 },
+    },
+    timed_life = {
+        duration = 3.2,
+    }
+}

--- a/content/projectiles/inferno_stream.lua
+++ b/content/projectiles/inferno_stream.lua
@@ -1,0 +1,24 @@
+return {
+    id = "inferno_stream",
+    name = "Inferno Stream",
+    class = "Projectile",
+    physics = {
+        speed = 4600,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "flame",
+            radius = 2.2,
+            color = {1.00, 0.45, 0.05, 0.95},
+        }
+    },
+    damage = {
+        value = 3.5,
+        damageOverTime = { amount = 1.5, duration = 3.5 },
+    },
+    timed_life = {
+        duration = 1.8,
+    }
+}

--- a/content/projectiles/ion_cluster_burst.lua
+++ b/content/projectiles/ion_cluster_burst.lua
@@ -1,0 +1,24 @@
+return {
+    id = "ion_cluster_burst",
+    name = "Ion Cluster Burst",
+    class = "Projectile",
+    physics = {
+        speed = 4400,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "ion",
+            radius = 2.0,
+            color = {0.55, 0.95, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 3.0,
+        ionChance = 0.35,
+    },
+    timed_life = {
+        duration = 2.4,
+    }
+}

--- a/content/projectiles/nanite_cloud.lua
+++ b/content/projectiles/nanite_cloud.lua
@@ -1,0 +1,25 @@
+return {
+    id = "nanite_cloud",
+    name = "Nanite Cloud",
+    class = "Projectile",
+    physics = {
+        speed = 2800,
+        drag = 0.08,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "cloud",
+            radius = 2.8,
+            color = {0.45, 0.95, 0.85, 0.8},
+        }
+    },
+    damage = {
+        value = 2.0,
+        healAllies = 2.0,
+        naniteDuration = 3.0,
+    },
+    timed_life = {
+        duration = 2.6,
+    }
+}

--- a/content/projectiles/plasma_lance_bolt.lua
+++ b/content/projectiles/plasma_lance_bolt.lua
@@ -1,0 +1,23 @@
+return {
+    id = "plasma_lance_bolt",
+    name = "Plasma Lance Bolt",
+    class = "Projectile",
+    physics = {
+        speed = 5200,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "plasma",
+            radius = 2.4,
+            color = {0.90, 0.45, 1.00, 1.0},
+        }
+    },
+    damage = {
+        value = 5.2,
+    },
+    timed_life = {
+        duration = 2.5,
+    }
+}

--- a/content/projectiles/rail_lance_spike.lua
+++ b/content/projectiles/rail_lance_spike.lua
@@ -1,0 +1,23 @@
+return {
+    id = "rail_lance_spike",
+    name = "Rail Spike",
+    class = "Projectile",
+    physics = {
+        speed = 7200,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "spike",
+            radius = 2.2,
+            color = {0.80, 0.95, 1.00, 1.0},
+        }
+    },
+    damage = {
+        value = 7.5,
+    },
+    timed_life = {
+        duration = 3.8,
+    }
+}

--- a/content/projectiles/rapid_burst_round.lua
+++ b/content/projectiles/rapid_burst_round.lua
@@ -1,0 +1,23 @@
+return {
+    id = "rapid_burst_round",
+    name = "Burst Micro-Slug",
+    class = "Projectile",
+    physics = {
+        speed = 4200,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "bullet",
+            radius = 1.6,
+            color = {0.35, 0.80, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 1.2,
+    },
+    timed_life = {
+        duration = 2.0,
+    }
+}

--- a/content/projectiles/scatter_pellet.lua
+++ b/content/projectiles/scatter_pellet.lua
@@ -1,0 +1,23 @@
+return {
+    id = "scatter_pellet",
+    name = "Scatter Pellet",
+    class = "Projectile",
+    physics = {
+        speed = 3600,
+        drag = 0.1,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "pellet",
+            radius = 1.2,
+            color = {1.00, 0.70, 0.25, 0.85},
+        }
+    },
+    damage = {
+        value = 0.9,
+    },
+    timed_life = {
+        duration = 1.2,
+    }
+}

--- a/content/projectiles/seeker_missile.lua
+++ b/content/projectiles/seeker_missile.lua
@@ -1,0 +1,23 @@
+return {
+    id = "seeker_missile",
+    name = "Seeker Missile",
+    class = "Projectile",
+    physics = {
+        speed = 950,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "missile",
+            radius = 3.4,
+            color = {0.00, 0.85, 1.00, 0.9},
+        }
+    },
+    damage = {
+        value = 3.6,
+    },
+    timed_life = {
+        duration = 4.8,
+    }
+}

--- a/content/projectiles/shard_spike.lua
+++ b/content/projectiles/shard_spike.lua
@@ -1,0 +1,24 @@
+return {
+    id = "shard_spike",
+    name = "Shard Spike",
+    class = "Projectile",
+    physics = {
+        speed = 5000,
+        drag = 0.02,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "spike",
+            radius = 1.8,
+            color = {0.90, 0.40, 0.95, 0.9},
+        }
+    },
+    damage = {
+        value = 3.2,
+        bleedingChance = 0.3,
+    },
+    timed_life = {
+        duration = 2.6,
+    }
+}

--- a/content/projectiles/siege_shell.lua
+++ b/content/projectiles/siege_shell.lua
@@ -1,0 +1,24 @@
+return {
+    id = "siege_shell",
+    name = "Siege Shell",
+    class = "Projectile",
+    physics = {
+        speed = 2200,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "shell",
+            radius = 3.4,
+            color = {0.95, 0.75, 0.45, 0.9},
+        }
+    },
+    damage = {
+        value = 6.2,
+        splash = 120,
+    },
+    timed_life = {
+        duration = 3.4,
+    }
+}

--- a/content/projectiles/solar_flare.lua
+++ b/content/projectiles/solar_flare.lua
@@ -1,0 +1,25 @@
+return {
+    id = "solar_flare",
+    name = "Solar Flare",
+    class = "Projectile",
+    physics = {
+        speed = 4400,
+        drag = 0.05,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "flare",
+            radius = 2.4,
+            color = {1.00, 0.70, 0.20, 0.9},
+        }
+    },
+    damage = {
+        value = 3.8,
+        burnRadius = 160,
+        burnDamage = { amount = 1.2, duration = 4.0 },
+    },
+    timed_life = {
+        duration = 2.6,
+    }
+}

--- a/content/projectiles/storm_missile.lua
+++ b/content/projectiles/storm_missile.lua
@@ -1,0 +1,24 @@
+return {
+    id = "storm_missile",
+    name = "Storm Missile",
+    class = "Projectile",
+    physics = {
+        speed = 900,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "missile",
+            radius = 3.2,
+            color = {1.00, 0.65, 0.25, 0.9},
+        }
+    },
+    damage = {
+        value = 3.0,
+        splash = 60,
+    },
+    timed_life = {
+        duration = 4.2,
+    }
+}

--- a/content/projectiles/tidal_wave.lua
+++ b/content/projectiles/tidal_wave.lua
@@ -1,0 +1,25 @@
+return {
+    id = "tidal_wave",
+    name = "Tidal Wave",
+    class = "Projectile",
+    physics = {
+        speed = 3400,
+        drag = 0.03,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "wave",
+            radius = 2.6,
+            color = {0.30, 0.75, 1.00, 0.85},
+        }
+    },
+    damage = {
+        value = 2.2,
+        knockbackForce = 280,
+        waveRadius = 220,
+    },
+    timed_life = {
+        duration = 3.0,
+    }
+}

--- a/content/projectiles/void_lance_beam.lua
+++ b/content/projectiles/void_lance_beam.lua
@@ -1,0 +1,25 @@
+return {
+    id = "void_lance_beam",
+    name = "Void Lance Beam",
+    class = "Projectile",
+    physics = {
+        speed = 5600,
+        drag = 0,
+    },
+    renderable = {
+        type = "bullet",
+        props = {
+            kind = "beam",
+            radius = 2.2,
+            color = {0.85, 0.40, 1.00, 0.95},
+        }
+    },
+    damage = {
+        value = 5.5,
+        shieldBypass = 0.6,
+        energyLeech = 3.0,
+    },
+    timed_life = {
+        duration = 3.0,
+    }
+}

--- a/content/turrets/arc_thrower_turret.lua
+++ b/content/turrets/arc_thrower_turret.lua
@@ -1,0 +1,42 @@
+return {
+    id = "arc_thrower_turret",
+    type = "laser",
+    name = "Arc Thrower",
+    description = "Voltage projector that hurls chaining arcs of electricity across clustered foes.",
+    price = 2600,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.05, 0.08, 0.12, 1}, x = 9, y = 12, w = 16, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.10, 0.20, 0.35, 1}, x = 16, y = 18, r = 4 },
+            { type = "polygon", mode = "fill", color = {0.55, 0.95, 1.00, 0.9}, points = {12, 8, 20, 8, 18, 4, 14, 4} },
+            { type = "polygon", mode = "line", color = {0.35, 0.85, 1.00, 0.85}, points = {13, 6, 16, 2, 19, 6}, lineWidth = 1.2 },
+        }
+    },
+    spread = { minDeg = 0.0, maxDeg = 0.1, decay = 1000 },
+    projectile = "arc_dart",
+    tracer = { color = {0.55, 0.95, 1.00, 0.9}, width = 1.8, coreRadius = 1.2 },
+    impact = {
+        shield = { spanDeg = 90, color1 = {0.55, 0.95, 1.0, 0.7}, color2 = {0.35, 0.75, 1.0, 0.45} },
+        hull = { spark = {0.75, 0.95, 1.0, 0.6}, ring = {0.40, 0.70, 1.0, 0.45} },
+    },
+    optimal = 950,
+    falloff = 650,
+    damage_range = { min = 3, max = 4.5 },
+    cycle = 0.9,
+    capCost = 4,
+    projectileSpeed = 4800,
+    maxRange = 1600,
+    chainChance = 0.6,
+    chainRange = 280,
+    maxChains = 4,
+    chainDamageFalloff = 0.7,
+    maxHeat = 110,
+    heatPerShot = 12,
+    cooldownRate = 26,
+    overheatCooldown = 4.5,
+    heatCycleMult = 0.65,
+    heatEnergyMult = 1.25,
+    fireMode = "automatic"
+}

--- a/content/turrets/breach_driver_turret.lua
+++ b/content/turrets/breach_driver_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "breach_driver_turret",
+    type = "gun",
+    name = "Breach Driver",
+    description = "Focused breaching cannon that specializes in hull penetration and subsystem damage.",
+    price = 2900,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.07, 0.08, 0.14, 1}, x = 9, y = 10, w = 16, h = 16, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.26, 0.34, 1}, x = 13, y = 6, w = 8, h = 18, rx = 2 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.45, 0.15, 0.85}, points = {14, 4, 18, 4, 19, 0, 13, 0} },
+            { type = "circle", mode = "fill", color = {1.00, 0.55, 0.35, 0.8}, x = 16, y = 20, r = 2.5 },
+        }
+    },
+    spread = { minDeg = 0.08, maxDeg = 0.3, decay = 900 },
+    projectile = "breach_round",
+    tracer = { color = {1.00, 0.55, 0.35, 0.9}, width = 1.6, coreRadius = 2 },
+    impact = {
+        shield = { spanDeg = 80, color1 = {1.0, 0.60, 0.30, 0.6}, color2 = {0.95, 0.45, 0.20, 0.4} },
+        hull = { spark = {1.0, 0.55, 0.20, 0.6}, ring = {1.0, 0.40, 0.10, 0.45} },
+    },
+    optimal = 1500,
+    falloff = 900,
+    damage_range = { min = 5, max = 6.5 },
+    cycle = 2.6,
+    capCost = 4.5,
+    projectileSpeed = 5600,
+    maxRange = 2400,
+    subsystemDamage = 1.5,
+    maxHeat = 105,
+    heatPerShot = 14,
+    cooldownRate = 20,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.65,
+    heatEnergyMult = 1.3,
+    fireMode = "manual"
+}

--- a/content/turrets/cluster_barrage_turret.lua
+++ b/content/turrets/cluster_barrage_turret.lua
@@ -1,0 +1,42 @@
+return {
+    id = "cluster_barrage_turret",
+    type = "missile",
+    name = "Cluster Barrage",
+    description = "Heavy launcher that fires cluster warheads splitting into bomblets.",
+    price = 3600,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.10, 0.12, 0.18, 1}, x = 8, y = 10, w = 18, h = 18, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.28, 0.36, 1}, x = 10, y = 12, w = 14, h = 14, rx = 2 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.45, 0.20, 0.9}, points = {12, 8, 20, 8, 18, 4, 14, 4} },
+            { type = "circle", mode = "fill", color = {1.00, 0.70, 0.25, 0.85}, x = 16, y = 18, r = 3 },
+        }
+    },
+    spread = { minDeg = 1.2, maxDeg = 4.5, decay = 280 },
+    projectile = "cluster_warhead",
+    tracer = { color = {1.00, 0.50, 0.20, 0.9}, width = 2.6, coreRadius = 5 },
+    impact = {
+        shield = { spanDeg = 85, color1 = {1.0, 0.60, 0.30, 0.6}, color2 = {1.0, 0.40, 0.15, 0.4} },
+        hull = { spark = {1.0, 0.50, 0.15, 0.6}, ring = {1.0, 0.35, 0.05, 0.4} },
+    },
+    optimal = 1500,
+    falloff = 2800,
+    damage_range = { min = 4, max = 6 },
+    cycle = 5.0,
+    capCost = 8,
+    homingStrength = 0.6,
+    missileTurnRate = 3.5,
+    projectileSpeed = 700,
+    maxRange = 3200,
+    bomblets = 6,
+    maxHeat = 70,
+    heatPerShot = 18,
+    cooldownRate = 12,
+    overheatCooldown = 5.5,
+    heatCycleMult = 0.5,
+    heatEnergyMult = 1.4,
+    fireMode = "manual",
+    lockOnDuration = 2.5
+}

--- a/content/turrets/corrosion_ray_turret.lua
+++ b/content/turrets/corrosion_ray_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "corrosion_ray_turret",
+    type = "laser",
+    name = "Corrosion Ray",
+    description = "Chemical beam that corrodes hull plating and reduces armor effectiveness.",
+    price = 2100,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.07, 0.09, 0.11, 1}, x = 9, y = 12, w = 16, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.25, 0.35, 0.20, 1}, x = 16, y = 18, r = 4 },
+            { type = "polygon", mode = "fill", color = {0.65, 0.85, 0.35, 0.9}, points = {12, 8, 20, 8, 18, 4, 14, 4} },
+            { type = "polygon", mode = "fill", color = {0.85, 1.00, 0.45, 0.8}, points = {14, 6, 18, 6, 19, 2, 13, 2} },
+        }
+    },
+    spread = { minDeg = 0.1, maxDeg = 0.4, decay = 900 },
+    projectile = "corrosion_stream",
+    tracer = { color = {0.75, 0.95, 0.45, 0.9}, width = 1.6, coreRadius = 1.1 },
+    impact = {
+        shield = { spanDeg = 70, color1 = {0.75, 0.95, 0.45, 0.55}, color2 = {0.55, 0.80, 0.30, 0.4} },
+        hull = { spark = {0.75, 0.90, 0.35, 0.55}, ring = {0.55, 0.70, 0.25, 0.45} },
+    },
+    optimal = 900,
+    falloff = 500,
+    damage_range = { min = 2, max = 3.5 },
+    cycle = 0.7,
+    capCost = 3.2,
+    projectileSpeed = 4200,
+    maxRange = 1400,
+    armorCorrosion = { multiplier = 0.7, duration = 3.0 },
+    maxHeat = 85,
+    heatPerShot = 6,
+    cooldownRate = 24,
+    overheatCooldown = 4.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.15,
+    fireMode = "automatic"
+}

--- a/content/turrets/cryo_beam_turret.lua
+++ b/content/turrets/cryo_beam_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "cryo_beam_turret",
+    type = "laser",
+    name = "Cryo Beam",
+    description = "Stasis beam that chills targets, reducing their movement and fire rate.",
+    price = 2400,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "polygon", mode = "fill", color = {0.05, 0.08, 0.12, 1}, points = {6, 24, 10, 12, 22, 12, 26, 24, 16, 28} },
+            { type = "circle", mode = "fill", color = {0.20, 0.35, 0.55, 1}, x = 16, y = 16, r = 6 },
+            { type = "circle", mode = "fill", color = {0.55, 0.90, 1.00, 0.9}, x = 16, y = 10, r = 4 },
+            { type = "polygon", mode = "fill", color = {0.75, 1.00, 1.00, 0.8}, points = {14, 6, 18, 6, 19, 2, 13, 2} },
+        }
+    },
+    spread = { minDeg = 0.0, maxDeg = 0.05, decay = 1200 },
+    projectile = "cryo_beam",
+    tracer = { color = {0.55, 0.90, 1.00, 0.9}, width = 1.5, coreRadius = 1.0 },
+    impact = {
+        shield = { spanDeg = 85, color1 = {0.55, 0.90, 1.0, 0.65}, color2 = {0.35, 0.70, 1.0, 0.45} },
+        hull = { spark = {0.65, 0.95, 1.0, 0.6}, ring = {0.35, 0.75, 1.0, 0.45} },
+    },
+    optimal = 1000,
+    falloff = 600,
+    damage_range = { min = 2, max = 3 },
+    cycle = 0.6,
+    capCost = 3,
+    projectileSpeed = 5000,
+    maxRange = 1500,
+    slowEffect = { multiplier = 0.6, duration = 2.5 },
+    maxHeat = 90,
+    heatPerShot = 7,
+    cooldownRate = 24,
+    overheatCooldown = 4.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.1,
+    fireMode = "automatic"
+}

--- a/content/turrets/disruptor_array_turret.lua
+++ b/content/turrets/disruptor_array_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "disruptor_array_turret",
+    type = "laser",
+    name = "Disruptor Array",
+    description = "Multi-phase emitter that disrupts shields and destabilizes energy systems.",
+    price = 3000,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.06, 0.08, 0.14, 1}, x = 8, y = 11, w = 18, h = 15, rx = 2 },
+            { type = "circle", mode = "fill", color = {0.15, 0.25, 0.45, 1}, x = 16, y = 17, r = 5 },
+            { type = "polygon", mode = "fill", color = {0.45, 0.95, 1.00, 0.9}, points = {12, 6, 20, 6, 18, 2, 14, 2} },
+            { type = "polygon", mode = "line", color = {0.35, 0.85, 1.00, 0.8}, points = {12, 10, 20, 10, 16, 4}, lineWidth = 1 },
+        }
+    },
+    spread = { minDeg = 0.05, maxDeg = 0.3, decay = 1000 },
+    projectile = "disruptor_wave",
+    tracer = { color = {0.45, 0.95, 1.00, 0.9}, width = 2.0, coreRadius = 1.1 },
+    impact = {
+        shield = { spanDeg = 100, color1 = {0.45, 0.95, 1.0, 0.7}, color2 = {0.25, 0.75, 1.0, 0.45} },
+        hull = { spark = {0.55, 0.90, 1.0, 0.55}, ring = {0.30, 0.70, 1.0, 0.4} },
+    },
+    optimal = 1500,
+    falloff = 900,
+    damage_range = { min = 3, max = 5 },
+    cycle = 1.4,
+    capCost = 5.5,
+    projectileSpeed = 5400,
+    maxRange = 2100,
+    shieldBreaker = 1.6,
+    maxHeat = 130,
+    heatPerShot = 18,
+    cooldownRate = 30,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.75,
+    heatEnergyMult = 1.35,
+    fireMode = "automatic"
+}

--- a/content/turrets/emp_pulse_turret.lua
+++ b/content/turrets/emp_pulse_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "emp_pulse_turret",
+    type = "support",
+    name = "EMP Pulse Projector",
+    description = "Delivers wide electromagnetic pulses that disable shields and systems.",
+    price = 2750,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.05, 0.08, 0.12, 1}, x = 9, y = 11, w = 16, h = 15, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.15, 0.25, 0.38, 1}, x = 16, y = 18, r = 5 },
+            { type = "circle", mode = "line", color = {0.00, 0.75, 1.00, 0.85}, x = 16, y = 8, r = 4, lineWidth = 2 },
+            { type = "circle", mode = "line", color = {0.35, 0.90, 1.00, 0.75}, x = 16, y = 8, r = 6, lineWidth = 1.4 },
+        }
+    },
+    spread = { minDeg = 0.3, maxDeg = 1.5, decay = 600 },
+    projectile = "emp_pulse",
+    tracer = { color = {0.35, 0.90, 1.00, 0.85}, width = 2.4, coreRadius = 3 },
+    impact = {
+        shield = { spanDeg = 120, color1 = {0.35, 0.90, 1.0, 0.7}, color2 = {0.15, 0.70, 1.0, 0.45} },
+        hull = { spark = {0.40, 0.90, 1.0, 0.55}, ring = {0.20, 0.70, 1.0, 0.4} },
+    },
+    optimal = 1000,
+    falloff = 1200,
+    damage_range = { min = 1, max = 2 },
+    cycle = 3.2,
+    capCost = 6,
+    projectileSpeed = 3200,
+    maxRange = 2000,
+    empStrength = { shield = 2.2, systems = 1.6, duration = 3.5 },
+    maxHeat = 90,
+    heatPerShot = 15,
+    cooldownRate = 18,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.3,
+    fireMode = "manual"
+}

--- a/content/turrets/flak_guard_turret.lua
+++ b/content/turrets/flak_guard_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "flak_guard_turret",
+    type = "gun",
+    name = "Flak Guard",
+    description = "Explosive flak launcher tuned for intercepting fighters and missiles.",
+    price = 1200,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.08, 0.11, 0.16, 1}, x = 8, y = 12, w = 18, h = 14, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.20, 0.28, 0.36, 1}, x = 12, y = 8, w = 10, h = 18, rx = 2 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.55, 0.25, 0.9}, points = {14, 6, 18, 6, 20, 4, 12, 4} },
+            { type = "circle", mode = "fill", color = {1.00, 0.80, 0.35, 0.8}, x = 16, y = 20, r = 3 },
+        }
+    },
+    spread = { minDeg = 1.5, maxDeg = 5.0, decay = 300 },
+    projectile = "flak_shard",
+    tracer = { color = {1.00, 0.75, 0.35, 0.9}, width = 1.6, coreRadius = 2.5 },
+    impact = {
+        shield = { spanDeg = 70, color1 = {1.0, 0.75, 0.45, 0.6}, color2 = {1.0, 0.55, 0.30, 0.4} },
+        hull = { spark = {1.0, 0.75, 0.25, 0.7}, ring = {1.0, 0.55, 0.15, 0.5} },
+    },
+    optimal = 600,
+    falloff = 500,
+    damage_range = { min = 2, max = 4 },
+    cycle = 1.2,
+    capCost = 3,
+    projectileSpeed = 3200,
+    maxRange = 1600,
+    explosionRadius = 80,
+    maxHeat = 90,
+    heatPerShot = 12,
+    cooldownRate = 18,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.65,
+    heatEnergyMult = 1.25,
+    fireMode = "automatic"
+}

--- a/content/turrets/fusion_pulse_turret.lua
+++ b/content/turrets/fusion_pulse_turret.lua
@@ -1,0 +1,38 @@
+return {
+    id = "fusion_pulse_turret",
+    type = "laser",
+    name = "Fusion Pulse",
+    description = "Radiant beam emitter that channels pulsed fusion energy into targets.",
+    price = 2800,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "polygon", mode = "fill", color = {0.06, 0.09, 0.16, 1}, points = {8, 24, 12, 10, 20, 10, 24, 24, 16, 28} },
+            { type = "circle", mode = "fill", color = {0.18, 0.26, 0.40, 1}, x = 16, y = 18, r = 5 },
+            { type = "circle", mode = "fill", color = {1.00, 0.60, 0.10, 0.9}, x = 16, y = 10, r = 4 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.80, 0.35, 0.8}, points = {14, 6, 18, 6, 20, 2, 12, 2} },
+        }
+    },
+    spread = { minDeg = 0.1, maxDeg = 0.2, decay = 900 },
+    projectile = "fusion_pulse_beam",
+    tracer = { color = {1.00, 0.60, 0.20, 0.9}, width = 1.8, coreRadius = 1.0 },
+    impact = {
+        shield = { spanDeg = 95, color1 = {1.0, 0.70, 0.30, 0.6}, color2 = {1.0, 0.45, 0.20, 0.45} },
+        hull = { spark = {1.0, 0.55, 0.20, 0.6}, ring = {1.0, 0.40, 0.10, 0.4} },
+    },
+    optimal = 1300,
+    falloff = 800,
+    damage_range = { min = 3, max = 6 },
+    cycle = 1.6,
+    capCost = 4.5,
+    projectileSpeed = 5000,
+    maxRange = 2000,
+    maxHeat = 120,
+    heatPerShot = 14,
+    cooldownRate = 32,
+    overheatCooldown = 4.5,
+    heatCycleMult = 0.75,
+    heatEnergyMult = 1.25,
+    fireMode = "automatic"
+}

--- a/content/turrets/graviton_well_turret.lua
+++ b/content/turrets/graviton_well_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "graviton_well_turret",
+    type = "cannon",
+    name = "Graviton Well",
+    description = "Launches compressive gravity orbs that slow and pull nearby enemies.",
+    price = 3100,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.07, 0.08, 0.12, 1}, x = 8, y = 11, w = 18, h = 15, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.12, 0.20, 0.32, 1}, x = 16, y = 18, r = 5 },
+            { type = "circle", mode = "fill", color = {0.45, 0.30, 0.95, 0.9}, x = 16, y = 9, r = 4 },
+            { type = "polygon", mode = "line", color = {0.65, 0.55, 1.00, 0.8}, points = {13, 6, 16, 2, 19, 6}, lineWidth = 1.2 },
+        }
+    },
+    spread = { minDeg = 0.5, maxDeg = 1.8, decay = 600 },
+    projectile = "graviton_orb",
+    tracer = { color = {0.65, 0.55, 1.00, 0.9}, width = 2.2, coreRadius = 2.8 },
+    impact = {
+        shield = { spanDeg = 85, color1 = {0.65, 0.55, 1.0, 0.65}, color2 = {0.45, 0.40, 1.0, 0.45} },
+        hull = { spark = {0.75, 0.65, 1.0, 0.55}, ring = {0.45, 0.40, 1.0, 0.4} },
+    },
+    optimal = 800,
+    falloff = 900,
+    damage_range = { min = 3, max = 4 },
+    cycle = 2.2,
+    capCost = 4.2,
+    projectileSpeed = 2600,
+    maxRange = 1700,
+    gravityWell = { radius = 180, force = 140, duration = 2.5 },
+    maxHeat = 95,
+    heatPerShot = 14,
+    cooldownRate = 18,
+    overheatCooldown = 4.8,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.3,
+    fireMode = "manual"
+}

--- a/content/turrets/heavy_gauss_turret.lua
+++ b/content/turrets/heavy_gauss_turret.lua
@@ -1,0 +1,38 @@
+return {
+    id = "heavy_gauss_turret",
+    type = "gun",
+    name = "Heavy Gauss Driver",
+    description = "High-mass coilgun that fires super-dense slugs for armor piercing damage.",
+    price = 2100,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.06, 0.08, 0.14, 1}, x = 7, y = 10, w = 18, h = 14, rx = 2 },
+            { type = "rectangle", mode = "fill", color = {0.18, 0.22, 0.30, 1}, x = 11, y = 6, w = 10, h = 20, rx = 2 },
+            { type = "rectangle", mode = "fill", color = {0.70, 0.85, 1.00, 0.9}, x = 14, y = 2, w = 4, h = 8 },
+            { type = "circle", mode = "fill", color = {0.35, 0.70, 1.00, 0.8}, x = 16, y = 20, r = 2.5 },
+        }
+    },
+    spread = { minDeg = 0.05, maxDeg = 0.25, decay = 800 },
+    projectile = "gauss_slug",
+    tracer = { color = {0.65, 0.85, 1.00, 1.0}, width = 1.8, coreRadius = 2.5 },
+    impact = {
+        shield = { spanDeg = 90, color1 = {0.40, 0.85, 1.0, 0.6}, color2 = {0.25, 0.55, 1.0, 0.4} },
+        hull = { spark = {0.85, 0.95, 1.0, 0.6}, ring = {0.45, 0.65, 1.0, 0.5} },
+    },
+    optimal = 1400,
+    falloff = 800,
+    damage_range = { min = 4, max = 7 },
+    cycle = 3.5,
+    capCost = 6,
+    projectileSpeed = 6000,
+    maxRange = 2600,
+    maxHeat = 120,
+    heatPerShot = 22,
+    cooldownRate = 18,
+    overheatCooldown = 6.0,
+    heatCycleMult = 0.7,
+    heatEnergyMult = 1.4,
+    fireMode = "manual"
+}

--- a/content/turrets/inferno_caster_turret.lua
+++ b/content/turrets/inferno_caster_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "inferno_caster_turret",
+    type = "laser",
+    name = "Inferno Caster",
+    description = "Continuous flame beam that applies stacking burn damage over time.",
+    price = 2300,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.09, 0.07, 0.05, 1}, x = 8, y = 12, w = 18, h = 14, rx = 3 },
+            { type = "polygon", mode = "fill", color = {0.60, 0.20, 0.05, 1}, points = {12, 10, 20, 10, 18, 4, 14, 4} },
+            { type = "circle", mode = "fill", color = {1.00, 0.45, 0.05, 0.9}, x = 16, y = 18, r = 3.5 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.70, 0.25, 0.8}, points = {14, 6, 18, 6, 19, 2, 13, 2} },
+        }
+    },
+    spread = { minDeg = 0.0, maxDeg = 0.1, decay = 1000 },
+    projectile = "inferno_stream",
+    tracer = { color = {1.00, 0.45, 0.05, 0.9}, width = 2.2, coreRadius = 1.2 },
+    impact = {
+        shield = { spanDeg = 70, color1 = {1.0, 0.55, 0.20, 0.6}, color2 = {1.0, 0.35, 0.05, 0.4} },
+        hull = { spark = {1.0, 0.45, 0.05, 0.6}, ring = {1.0, 0.30, 0.02, 0.45} },
+    },
+    optimal = 900,
+    falloff = 400,
+    damage_range = { min = 2, max = 4 },
+    cycle = 0.4,
+    capCost = 3.5,
+    projectileSpeed = 4600,
+    maxRange = 1200,
+    damageOverTime = { amount = 1.5, duration = 3.5 },
+    maxHeat = 100,
+    heatPerShot = 5,
+    cooldownRate = 25,
+    overheatCooldown = 4.0,
+    heatCycleMult = 0.55,
+    heatEnergyMult = 1.2,
+    fireMode = "automatic"
+}

--- a/content/turrets/ion_cluster_turret.lua
+++ b/content/turrets/ion_cluster_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "ion_cluster_turret",
+    type = "gun",
+    name = "Ion Cluster",
+    description = "Charged ion blaster that releases clusters of electrified shards.",
+    price = 1800,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.07, 0.09, 0.15, 1}, x = 9, y = 12, w = 16, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.20, 0.30, 0.45, 1}, x = 16, y = 18, r = 4 },
+            { type = "circle", mode = "fill", color = {0.55, 0.95, 1.00, 0.9}, x = 13, y = 12, r = 2.5 },
+            { type = "circle", mode = "fill", color = {0.35, 0.85, 1.00, 0.85}, x = 19, y = 12, r = 2.5 },
+        }
+    },
+    spread = { minDeg = 0.8, maxDeg = 3.0, decay = 500 },
+    projectile = "ion_cluster_burst",
+    tracer = { color = {0.55, 0.95, 1.00, 0.9}, width = 1.4, coreRadius = 1.6 },
+    impact = {
+        shield = { spanDeg = 75, color1 = {0.55, 0.95, 1.0, 0.65}, color2 = {0.35, 0.75, 1.0, 0.45} },
+        hull = { spark = {0.80, 0.95, 1.0, 0.5}, ring = {0.45, 0.75, 1.0, 0.4} },
+    },
+    optimal = 700,
+    falloff = 600,
+    damage_range = { min = 2, max = 3.5 },
+    cycle = 0.5,
+    capCost = 2.2,
+    projectileSpeed = 4400,
+    maxRange = 1400,
+    ionChance = 0.35,
+    maxHeat = 85,
+    heatPerShot = 7,
+    cooldownRate = 22,
+    overheatCooldown = 3.8,
+    heatCycleMult = 0.55,
+    heatEnergyMult = 1.15,
+    fireMode = "automatic"
+}

--- a/content/turrets/nanite_sprayer_turret.lua
+++ b/content/turrets/nanite_sprayer_turret.lua
@@ -1,0 +1,41 @@
+return {
+    id = "nanite_sprayer_turret",
+    type = "support",
+    name = "Nanite Sprayer",
+    description = "Support turret that releases nanite clouds, repairing allies and harming foes.",
+    price = 2000,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.06, 0.10, 0.12, 1}, x = 8, y = 12, w = 18, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.10, 0.30, 0.30, 1}, x = 16, y = 18, r = 4 },
+            { type = "circle", mode = "fill", color = {0.35, 0.90, 0.80, 0.9}, x = 16, y = 10, r = 3 },
+            { type = "circle", mode = "fill", color = {0.55, 1.00, 0.85, 0.7}, x = 12, y = 8, r = 2 },
+            { type = "circle", mode = "fill", color = {0.55, 1.00, 0.85, 0.7}, x = 20, y = 8, r = 2 },
+        }
+    },
+    spread = { minDeg = 1.5, maxDeg = 4.5, decay = 300 },
+    projectile = "nanite_cloud",
+    tracer = { color = {0.45, 0.95, 0.85, 0.8}, width = 2.2, coreRadius = 2.5 },
+    impact = {
+        shield = { spanDeg = 60, color1 = {0.35, 0.95, 0.80, 0.55}, color2 = {0.25, 0.75, 0.65, 0.4} },
+        hull = { spark = {0.45, 0.95, 0.80, 0.5}, ring = {0.30, 0.75, 0.65, 0.35} },
+    },
+    optimal = 600,
+    falloff = 500,
+    damage_range = { min = 1.5, max = 2.5 },
+    cycle = 1.0,
+    capCost = 2.8,
+    projectileSpeed = 2800,
+    maxRange = 1200,
+    healAllies = 2.0,
+    naniteDuration = 3.0,
+    maxHeat = 80,
+    heatPerShot = 7,
+    cooldownRate = 22,
+    overheatCooldown = 4.2,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.1,
+    fireMode = "automatic"
+}

--- a/content/turrets/plasma_lance_turret.lua
+++ b/content/turrets/plasma_lance_turret.lua
@@ -1,0 +1,38 @@
+return {
+    id = "plasma_lance_turret",
+    type = "plasma",
+    name = "Plasma Lance",
+    description = "Superheated plasma injector that delivers searing bolts of energy.",
+    price = 2500,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "polygon", mode = "fill", color = {0.07, 0.10, 0.18, 1}, points = {6, 24, 10, 12, 22, 12, 26, 24, 16, 28} },
+            { type = "circle", mode = "fill", color = {0.20, 0.30, 0.45, 1}, x = 16, y = 16, r = 6 },
+            { type = "circle", mode = "fill", color = {0.85, 0.40, 1.00, 0.9}, x = 16, y = 10, r = 4 },
+            { type = "circle", mode = "fill", color = {1.00, 0.65, 0.25, 0.8}, x = 16, y = 6, r = 2 },
+        }
+    },
+    spread = { minDeg = 0.2, maxDeg = 0.8, decay = 700 },
+    projectile = "plasma_lance_bolt",
+    tracer = { color = {0.90, 0.45, 1.00, 1.0}, width = 1.6, coreRadius = 1.8 },
+    impact = {
+        shield = { spanDeg = 85, color1 = {0.90, 0.45, 1.0, 0.65}, color2 = {0.65, 0.30, 1.0, 0.4} },
+        hull = { spark = {1.0, 0.55, 0.35, 0.6}, ring = {1.0, 0.35, 0.25, 0.45} },
+    },
+    optimal = 1100,
+    falloff = 700,
+    damage_range = { min = 4, max = 6 },
+    cycle = 1.8,
+    capCost = 5,
+    projectileSpeed = 5200,
+    maxRange = 1800,
+    maxHeat = 110,
+    heatPerShot = 16,
+    cooldownRate = 28,
+    overheatCooldown = 4.5,
+    heatCycleMult = 0.7,
+    heatEnergyMult = 1.3,
+    fireMode = "automatic"
+}

--- a/content/turrets/rail_lance_turret.lua
+++ b/content/turrets/rail_lance_turret.lua
@@ -1,0 +1,38 @@
+return {
+    id = "rail_lance_turret",
+    type = "gun",
+    name = "Rail Lance",
+    description = "Ultra-high velocity spear that excels at punching through capital ships.",
+    price = 3200,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.05, 0.08, 0.14, 1}, x = 9, y = 10, w = 16, h = 16, rx = 2 },
+            { type = "rectangle", mode = "fill", color = {0.18, 0.26, 0.32, 1}, x = 13, y = 6, w = 8, h = 20, rx = 1 },
+            { type = "polygon", mode = "fill", color = {0.80, 0.95, 1.00, 0.9}, points = {14, 2, 18, 2, 19, 0, 13, 0} },
+            { type = "polygon", mode = "line", color = {0.35, 0.80, 1.00, 0.8}, points = {12, 8, 20, 8, 16, 20}, lineWidth = 1.2 },
+        }
+    },
+    spread = { minDeg = 0.02, maxDeg = 0.1, decay = 1200 },
+    projectile = "rail_lance_spike",
+    tracer = { color = {0.80, 0.95, 1.00, 1.0}, width = 1.2, coreRadius = 1.5 },
+    impact = {
+        shield = { spanDeg = 110, color1 = {0.55, 0.95, 1.0, 0.7}, color2 = {0.30, 0.70, 1.0, 0.45} },
+        hull = { spark = {0.90, 0.95, 1.0, 0.6}, ring = {0.45, 0.65, 1.0, 0.5} },
+    },
+    optimal = 2000,
+    falloff = 1000,
+    damage_range = { min = 6, max = 9 },
+    cycle = 4.5,
+    capCost = 8,
+    projectileSpeed = 7200,
+    maxRange = 3200,
+    maxHeat = 140,
+    heatPerShot = 26,
+    cooldownRate = 16,
+    overheatCooldown = 6.5,
+    heatCycleMult = 0.75,
+    heatEnergyMult = 1.5,
+    fireMode = "manual"
+}

--- a/content/turrets/rapid_burst_turret.lua
+++ b/content/turrets/rapid_burst_turret.lua
@@ -1,0 +1,38 @@
+return {
+    id = "rapid_burst_turret",
+    type = "gun",
+    name = "Rapid Burst Turret",
+    description = "Compact rotary cannon that saturates targets with kinetic bursts.",
+    price = 650,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.08, 0.12, 0.20, 1}, x = 6, y = 12, w = 20, h = 12, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.16, 0.24, 0.34, 1}, x = 10, y = 10, w = 12, h = 16, rx = 2 },
+            { type = "polygon", mode = "fill", color = {0.80, 0.90, 1.00, 0.9}, points = {14, 6, 18, 6, 20, 4, 12, 4} },
+            { type = "circle", mode = "fill", color = {0.25, 0.70, 1.00, 0.9}, x = 16, y = 18, r = 3 },
+        }
+    },
+    spread = { minDeg = 0.4, maxDeg = 2.4, decay = 500 },
+    projectile = "rapid_burst_round",
+    tracer = { color = {0.35, 0.80, 1.00, 0.9}, width = 1.2, coreRadius = 2 },
+    impact = {
+        shield = { spanDeg = 60, color1 = {0.45, 0.85, 1.0, 0.55}, color2 = {0.25, 0.65, 1.0, 0.35} },
+        hull = { spark = {1.0, 0.75, 0.25, 0.7}, ring = {1.0, 0.45, 0.15, 0.4} },
+    },
+    optimal = 500,
+    falloff = 450,
+    damage_range = { min = 0.8, max = 1.4 },
+    cycle = 0.25,
+    capCost = 1.5,
+    projectileSpeed = 4200,
+    maxRange = 1400,
+    maxHeat = 80,
+    heatPerShot = 6,
+    cooldownRate = 20,
+    overheatCooldown = 4.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.2,
+    fireMode = "automatic"
+}

--- a/content/turrets/scattershot_turret.lua
+++ b/content/turrets/scattershot_turret.lua
@@ -1,0 +1,40 @@
+return {
+    id = "scattershot_turret",
+    type = "gun",
+    name = "Scattershot Battery",
+    description = "Close-range turret that fires rapid clusters of micro-shrapnel.",
+    price = 900,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "polygon", mode = "fill", color = {0.10, 0.14, 0.20, 1}, points = {6, 24, 10, 10, 22, 10, 26, 24, 16, 28} },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.30, 0.36, 1}, x = 10, y = 12, w = 12, h = 12, rx = 2 },
+            { type = "circle", mode = "fill", color = {1.00, 0.65, 0.25, 0.9}, x = 12, y = 16, r = 2 },
+            { type = "circle", mode = "fill", color = {1.00, 0.85, 0.35, 0.8}, x = 16, y = 12, r = 2 },
+            { type = "circle", mode = "fill", color = {1.00, 0.55, 0.20, 0.8}, x = 20, y = 16, r = 2 },
+        }
+    },
+    spread = { minDeg = 2.5, maxDeg = 8.0, decay = 220 },
+    projectile = "scatter_pellet",
+    tracer = { color = {1.00, 0.70, 0.25, 0.8}, width = 2.0, coreRadius = 3 },
+    impact = {
+        shield = { spanDeg = 50, color1 = {1.0, 0.75, 0.35, 0.55}, color2 = {1.0, 0.55, 0.25, 0.35} },
+        hull = { spark = {1.0, 0.65, 0.15, 0.6}, ring = {1.0, 0.45, 0.05, 0.5} },
+    },
+    optimal = 300,
+    falloff = 250,
+    damage_range = { min = 3, max = 5 },
+    cycle = 0.8,
+    capCost = 2.5,
+    projectileSpeed = 3600,
+    maxRange = 900,
+    maxHeat = 70,
+    heatPerShot = 8,
+    cooldownRate = 22,
+    overheatCooldown = 4.0,
+    heatCycleMult = 0.5,
+    heatEnergyMult = 1.1,
+    fireMode = "automatic",
+    pelletsPerShot = 6
+}

--- a/content/turrets/seeker_pod_turret.lua
+++ b/content/turrets/seeker_pod_turret.lua
@@ -1,0 +1,42 @@
+return {
+    id = "seeker_pod_turret",
+    type = "missile",
+    name = "Seeker Pod",
+    description = "Smart missile pod that locks individual targets with precision tracking.",
+    price = 3200,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.08, 0.10, 0.16, 1}, x = 9, y = 10, w = 16, h = 18, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.18, 0.24, 0.32, 1}, x = 11, y = 12, w = 12, h = 14, rx = 2 },
+            { type = "circle", mode = "fill", color = {0.00, 0.75, 0.95, 0.9}, x = 13, y = 16, r = 2 },
+            { type = "circle", mode = "fill", color = {0.00, 0.75, 0.95, 0.9}, x = 19, y = 16, r = 2 },
+        }
+    },
+    spread = { minDeg = 0.5, maxDeg = 2.5, decay = 400 },
+    projectile = "seeker_missile",
+    tracer = { color = {0.00, 0.85, 1.00, 0.9}, width = 2.0, coreRadius = 3 },
+    impact = {
+        shield = { spanDeg = 75, color1 = {0.15, 0.85, 1.0, 0.65}, color2 = {0.05, 0.65, 1.0, 0.45} },
+        hull = { spark = {0.35, 0.85, 1.0, 0.6}, ring = {0.15, 0.65, 1.0, 0.45} },
+    },
+    optimal = 1700,
+    falloff = 2600,
+    damage_range = { min = 3, max = 4 },
+    cycle = 2.8,
+    capCost = 5.5,
+    homingStrength = 1.1,
+    missileTurnRate = 7.0,
+    projectileSpeed = 950,
+    maxRange = 3200,
+    lockPersistence = 3.5,
+    maxHeat = 85,
+    heatPerShot = 10,
+    cooldownRate = 18,
+    overheatCooldown = 4.8,
+    heatCycleMult = 0.65,
+    heatEnergyMult = 1.2,
+    fireMode = "manual",
+    lockOnDuration = 1.2
+}

--- a/content/turrets/shard_spitter_turret.lua
+++ b/content/turrets/shard_spitter_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "shard_spitter_turret",
+    type = "gun",
+    name = "Shard Spitter",
+    description = "Organic-inspired launcher that spits crystalline shards at blistering speed.",
+    price = 1500,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.08, 0.06, 0.10, 1}, x = 9, y = 12, w = 16, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.25, 0.10, 0.30, 1}, x = 16, y = 18, r = 4 },
+            { type = "polygon", mode = "fill", color = {0.90, 0.40, 0.95, 0.9}, points = {12, 8, 20, 8, 16, 2} },
+            { type = "circle", mode = "fill", color = {1.00, 0.75, 0.95, 0.8}, x = 16, y = 8, r = 2 },
+        }
+    },
+    spread = { minDeg = 0.6, maxDeg = 2.4, decay = 520 },
+    projectile = "shard_spike",
+    tracer = { color = {0.90, 0.40, 0.95, 0.9}, width = 1.4, coreRadius = 1.5 },
+    impact = {
+        shield = { spanDeg = 70, color1 = {0.90, 0.50, 1.0, 0.6}, color2 = {0.65, 0.30, 0.95, 0.4} },
+        hull = { spark = {0.95, 0.45, 1.0, 0.6}, ring = {0.70, 0.35, 0.95, 0.4} },
+    },
+    optimal = 800,
+    falloff = 700,
+    damage_range = { min = 2.5, max = 4.0 },
+    cycle = 0.45,
+    capCost = 2.0,
+    projectileSpeed = 5000,
+    maxRange = 1500,
+    bleedingChance = 0.3,
+    maxHeat = 90,
+    heatPerShot = 7,
+    cooldownRate = 24,
+    overheatCooldown = 4.2,
+    heatCycleMult = 0.55,
+    heatEnergyMult = 1.2,
+    fireMode = "automatic"
+}

--- a/content/turrets/siege_breaker_turret.lua
+++ b/content/turrets/siege_breaker_turret.lua
@@ -1,0 +1,39 @@
+return {
+    id = "siege_breaker_turret",
+    type = "cannon",
+    name = "Siege Breaker",
+    description = "Siege mortar that fires high arc shells for area bombardment.",
+    price = 2800,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "polygon", mode = "fill", color = {0.09, 0.08, 0.06, 1}, points = {6, 26, 12, 8, 20, 8, 26, 26, 16, 30} },
+            { type = "rectangle", mode = "fill", color = {0.24, 0.20, 0.12, 1}, x = 12, y = 10, w = 8, h = 16, rx = 2 },
+            { type = "polygon", mode = "fill", color = {0.75, 0.55, 0.25, 0.9}, points = {14, 8, 18, 8, 17, 4, 15, 4} },
+        }
+    },
+    spread = { minDeg = 1.0, maxDeg = 3.5, decay = 350 },
+    projectile = "siege_shell",
+    tracer = { color = {0.95, 0.75, 0.45, 0.9}, width = 2.4, coreRadius = 3 },
+    impact = {
+        shield = { spanDeg = 90, color1 = {0.95, 0.80, 0.50, 0.6}, color2 = {0.85, 0.60, 0.25, 0.45} },
+        hull = { spark = {1.0, 0.65, 0.30, 0.6}, ring = {1.0, 0.45, 0.20, 0.45} },
+    },
+    optimal = 900,
+    falloff = 1500,
+    damage_range = { min = 5, max = 7 },
+    cycle = 3.8,
+    capCost = 4.5,
+    projectileSpeed = 2200,
+    maxRange = 2400,
+    arcShot = true,
+    explosionRadius = 120,
+    maxHeat = 100,
+    heatPerShot = 16,
+    cooldownRate = 16,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.2,
+    fireMode = "manual"
+}

--- a/content/turrets/solar_flare_turret.lua
+++ b/content/turrets/solar_flare_turret.lua
@@ -1,0 +1,40 @@
+return {
+    id = "solar_flare_turret",
+    type = "laser",
+    name = "Solar Flare",
+    description = "Flare emitter that unleashes radiant bursts causing area burn damage.",
+    price = 2700,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.12, 0.08, 0.04, 1}, x = 8, y = 12, w = 18, h = 14, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.35, 0.18, 0.05, 1}, x = 16, y = 18, r = 4 },
+            { type = "circle", mode = "fill", color = {1.00, 0.65, 0.10, 0.9}, x = 16, y = 10, r = 3.5 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.85, 0.40, 0.8}, points = {13, 6, 16, 2, 19, 6, 16, 4} },
+        }
+    },
+    spread = { minDeg = 0.3, maxDeg = 1.2, decay = 700 },
+    projectile = "solar_flare",
+    tracer = { color = {1.00, 0.70, 0.20, 0.9}, width = 2.0, coreRadius = 2.2 },
+    impact = {
+        shield = { spanDeg = 90, color1 = {1.0, 0.70, 0.30, 0.6}, color2 = {1.0, 0.50, 0.15, 0.4} },
+        hull = { spark = {1.0, 0.55, 0.10, 0.6}, ring = {1.0, 0.45, 0.05, 0.45} },
+    },
+    optimal = 1000,
+    falloff = 800,
+    damage_range = { min = 3, max = 4.5 },
+    cycle = 1.2,
+    capCost = 4,
+    projectileSpeed = 4400,
+    maxRange = 1600,
+    burnRadius = 160,
+    burnDamage = { amount = 1.2, duration = 4.0 },
+    maxHeat = 115,
+    heatPerShot = 12,
+    cooldownRate = 26,
+    overheatCooldown = 4.8,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.2,
+    fireMode = "automatic"
+}

--- a/content/turrets/storm_missile_turret.lua
+++ b/content/turrets/storm_missile_turret.lua
@@ -1,0 +1,43 @@
+return {
+    id = "storm_missile_turret",
+    type = "missile",
+    name = "Storm Missile Rack",
+    description = "Quad launcher that saturates an area with agile micro-missiles.",
+    price = 3400,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.09, 0.11, 0.18, 1}, x = 7, y = 10, w = 18, h = 18, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.18, 0.26, 0.36, 1}, x = 9, y = 12, w = 14, h = 14, rx = 2 },
+            { type = "rectangle", mode = "fill", color = {0.85, 0.30, 0.25, 0.9}, x = 10, y = 8, w = 5, h = 10 },
+            { type = "rectangle", mode = "fill", color = {0.85, 0.30, 0.25, 0.9}, x = 17, y = 8, w = 5, h = 10 },
+            { type = "polygon", mode = "fill", color = {1.00, 0.60, 0.25, 0.85}, points = {12, 6, 20, 6, 22, 2, 10, 2} },
+        }
+    },
+    spread = { minDeg = 1.0, maxDeg = 4.0, decay = 320 },
+    projectile = "storm_missile",
+    tracer = { color = {1.00, 0.65, 0.25, 0.9}, width = 2.2, coreRadius = 4 },
+    impact = {
+        shield = { spanDeg = 80, color1 = {1.0, 0.70, 0.40, 0.6}, color2 = {1.0, 0.50, 0.25, 0.45} },
+        hull = { spark = {1.0, 0.55, 0.20, 0.6}, ring = {1.0, 0.40, 0.15, 0.4} },
+    },
+    optimal = 1300,
+    falloff = 2500,
+    damage_range = { min = 2.5, max = 3.5 },
+    cycle = 3.0,
+    capCost = 6,
+    homingStrength = 0.9,
+    missileTurnRate = 6.0,
+    projectileSpeed = 900,
+    maxRange = 2800,
+    volleyCount = 4,
+    maxHeat = 80,
+    heatPerShot = 12,
+    cooldownRate = 15,
+    overheatCooldown = 5.0,
+    heatCycleMult = 0.6,
+    heatEnergyMult = 1.3,
+    fireMode = "manual",
+    lockOnDuration = 1.5
+}

--- a/content/turrets/tidal_projector_turret.lua
+++ b/content/turrets/tidal_projector_turret.lua
@@ -1,0 +1,40 @@
+return {
+    id = "tidal_projector_turret",
+    type = "support",
+    name = "Tidal Projector",
+    description = "Gravitic wave projector that pushes enemies away and clears space lanes.",
+    price = 2600,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.05, 0.09, 0.11, 1}, x = 9, y = 11, w = 16, h = 15, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.10, 0.20, 0.30, 1}, x = 16, y = 18, r = 5 },
+            { type = "polygon", mode = "fill", color = {0.30, 0.75, 1.00, 0.85}, points = {12, 8, 20, 8, 16, 2} },
+            { type = "polygon", mode = "line", color = {0.50, 0.90, 1.00, 0.7}, points = {12, 6, 16, 2, 20, 6}, lineWidth = 1.4 },
+        }
+    },
+    spread = { minDeg = 0.4, maxDeg = 1.6, decay = 800 },
+    projectile = "tidal_wave",
+    tracer = { color = {0.30, 0.75, 1.00, 0.85}, width = 2.0, coreRadius = 2.5 },
+    impact = {
+        shield = { spanDeg = 95, color1 = {0.30, 0.75, 1.0, 0.6}, color2 = {0.15, 0.55, 0.9, 0.4} },
+        hull = { spark = {0.35, 0.80, 1.0, 0.5}, ring = {0.20, 0.60, 0.9, 0.35} },
+    },
+    optimal = 1200,
+    falloff = 1400,
+    damage_range = { min = 1.5, max = 2.5 },
+    cycle = 2.0,
+    capCost = 4.5,
+    projectileSpeed = 3400,
+    maxRange = 2200,
+    knockbackForce = 280,
+    waveRadius = 220,
+    maxHeat = 95,
+    heatPerShot = 12,
+    cooldownRate = 20,
+    overheatCooldown = 4.8,
+    heatCycleMult = 0.65,
+    heatEnergyMult = 1.25,
+    fireMode = "manual"
+}

--- a/content/turrets/void_lance_turret.lua
+++ b/content/turrets/void_lance_turret.lua
@@ -1,0 +1,40 @@
+return {
+    id = "void_lance_turret",
+    type = "laser",
+    name = "Void Lance",
+    description = "Experimental dark energy beam that bypasses shields and siphons energy.",
+    price = 3800,
+    module = { type = "turret" },
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.04, 0.05, 0.08, 1}, x = 9, y = 10, w = 16, h = 16, rx = 3 },
+            { type = "circle", mode = "fill", color = {0.10, 0.15, 0.25, 1}, x = 16, y = 18, r = 5 },
+            { type = "polygon", mode = "fill", color = {0.30, 0.10, 0.55, 0.9}, points = {12, 8, 20, 8, 18, 4, 14, 4} },
+            { type = "polygon", mode = "fill", color = {0.85, 0.40, 1.00, 0.85}, points = {14, 6, 18, 6, 19, 2, 13, 2} },
+        }
+    },
+    spread = { minDeg = 0.02, maxDeg = 0.12, decay = 1300 },
+    projectile = "void_lance_beam",
+    tracer = { color = {0.85, 0.40, 1.00, 0.95}, width = 1.4, coreRadius = 1.0 },
+    impact = {
+        shield = { spanDeg = 100, color1 = {0.60, 0.30, 0.95, 0.7}, color2 = {0.35, 0.15, 0.85, 0.5} },
+        hull = { spark = {0.80, 0.40, 1.0, 0.6}, ring = {0.45, 0.20, 0.85, 0.45} },
+    },
+    optimal = 1900,
+    falloff = 1100,
+    damage_range = { min = 4, max = 7 },
+    cycle = 2.4,
+    capCost = 7,
+    projectileSpeed = 5600,
+    maxRange = 2600,
+    shieldBypass = 0.6,
+    energyLeech = 3.0,
+    maxHeat = 140,
+    heatPerShot = 20,
+    cooldownRate = 32,
+    overheatCooldown = 5.5,
+    heatCycleMult = 0.75,
+    heatEnergyMult = 1.4,
+    fireMode = "manual"
+}


### PR DESCRIPTION
## Summary
- add twenty-five new turret modules spanning ballistic, energy, missile, and support roles with bespoke icons, firing parameters, and unique mechanics
- create corresponding projectile definitions so each turret fires a tailored round, beam, or missile with appropriate physics, damage, and status effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d93142beb483228d4b0ab342b4e0b9