### PR TITLE
Implement Save Slot Workflow

### DIFF
--- a/src/core/input.lua
+++ b/src/core/input.lua
@@ -220,7 +220,8 @@ function Input.love_mousepressed(x, y, button)
       mainState.setScreen("game")
       return
     elseif start == "loadGame" then
-      local selectedSlot = mainState.startScreen.loadSlotsUI and mainState.startScreen.loadSlotsUI.selectedSlot
+      local loadSlotsUI = mainState.startScreen.loadSlotsUI
+      local selectedSlot = loadSlotsUI and loadSlotsUI.getSelectedSlotIndex and loadSlotsUI:getSelectedSlotIndex()
       -- Load game from save (Game.load will handle save loading)
       Game.load(true, selectedSlot)
       mainState.UIManager = require("src.core.ui_manager")

--- a/src/ui/save_load.lua
+++ b/src/ui/save_load.lua
@@ -1,5 +1,3 @@
-local Theme = require("src.core.theme")
-local StateManager = require("src.managers.state_manager")
 local Window = require("src.ui.common.window")
 local SaveSlots = require("src.ui.save_slots")
 
@@ -15,10 +13,15 @@ function SaveLoad:new(options)
         onClose = o.onClose
     })
 
+    local preferredW, preferredH = o.saveSlots:getPreferredSize()
+    -- Add padding so the window chrome does not clip the content area
+    local windowW = math.max(420, preferredW + 40)
+    local windowH = math.max(540, preferredH + 60)
+
     o.window = Window.new({
         title = "Save & Load Game",
-        width = 400,
-        height = 500,
+        width = windowW,
+        height = windowH,
         useLoadPanelTheme = true,
         closable = true,
         onClose = function()
@@ -31,7 +34,7 @@ function SaveLoad:new(options)
     return o
 end
 
-function SaveLoad:mousepressed(player, mx, my, button, w, h)
+function SaveLoad:mousepressed(mx, my, button)
     return self.saveSlots:mousepressed(mx, my, button)
 end
 

--- a/src/ui/save_slots.lua
+++ b/src/ui/save_slots.lua
@@ -1,278 +1,391 @@
 local Theme = require("src.core.theme")
 local StateManager = require("src.managers.state_manager")
 
+local DEFAULT_SLOT_COUNT = 6
+
 local SaveSlots = {}
 
 function SaveSlots:new(options)
     local o = {}
     setmetatable(o, self)
     self.__index = self
-    o.selectedSlot = nil
-    o.newSaveName = ""
-    o.showNewSave = false
+
+    o.slotCount = options and options.slotCount or DEFAULT_SLOT_COUNT
     o.onClose = options and options.onClose
+    o.selectedSlot = nil -- numeric index (1-based)
+    o._slotOrder = {}
+    for i = 1, o.slotCount do
+        o._slotOrder[i] = string.format("slot%d", i)
+    end
+    o._slotLookup = nil
+    o._allSlots = nil
+    o._cacheDirty = true
+
     return o
 end
 
+function SaveSlots:_ensureCache()
+    if not self._cacheDirty and self._slotLookup then
+        return
+    end
+
+    local slots = StateManager.getSaveSlots()
+    self._allSlots = slots
+    self._slotLookup = {}
+    for _, slot in ipairs(slots) do
+        self._slotLookup[slot.name] = slot
+    end
+    self._cacheDirty = false
+
+    -- Clamp the selection to a valid index and default to first slot if none selected
+    local slotCount = #self._slotOrder
+    if not self.selectedSlot or self.selectedSlot < 1 or self.selectedSlot > slotCount then
+        self.selectedSlot = nil
+    end
+
+    if not self.selectedSlot then
+        -- Prefer first occupied slot, otherwise default to slot 1
+        for index, slotName in ipairs(self._slotOrder) do
+            if self._slotLookup[slotName] then
+                self.selectedSlot = index
+                break
+            end
+        end
+        if not self.selectedSlot and slotCount > 0 then
+            self.selectedSlot = 1
+        end
+    end
+end
+
+local function drawButtonRect(buttonFont, buttonPaddingX, buttonPaddingY, xPos, yPos, width, height, fillColor, label, enabled)
+    local color = enabled and fillColor or Theme.withAlpha(fillColor, 0.4)
+    Theme.setColor(color)
+    love.graphics.rectangle("fill", xPos, yPos, width, height)
+
+    local textColor = enabled and Theme.colors.text or Theme.withAlpha(Theme.colors.text, 0.5)
+    Theme.setColor(textColor)
+
+    local prevFont = love.graphics.getFont()
+    love.graphics.setFont(buttonFont)
+    local textW = buttonFont:getWidth(label)
+    local textH = buttonFont:getHeight()
+    local availableW = width - buttonPaddingX * 2
+    local availableH = height - buttonPaddingY * 2
+    if textW <= 0 or textH <= 0 then
+        love.graphics.print(label, xPos + buttonPaddingX, yPos + buttonPaddingY)
+        love.graphics.setFont(prevFont)
+        return
+    end
+    local scale = math.min(1, availableW / textW, availableH / textH)
+    if scale <= 0 then scale = availableH / textH end
+    local drawW = textW * scale
+    local drawH = textH * scale
+    local drawX = xPos + (width - drawW) / 2
+    local drawY = yPos + (height - drawH) / 2
+    love.graphics.print(label, drawX, drawY, 0, scale, scale)
+    love.graphics.setFont(prevFont)
+end
+
+local function computeButtonSize(buttonFont, paddingX, paddingY, minW, minH, label)
+    local prevFont = love.graphics.getFont()
+    love.graphics.setFont(buttonFont)
+    local textW = buttonFont:getWidth(label)
+    local textH = buttonFont:getHeight()
+    love.graphics.setFont(prevFont)
+    local width = math.max(minW, textW + paddingX * 2)
+    local height = math.max(minH, textH + paddingY * 2)
+    return width, height, textW, textH
+end
+
+function SaveSlots:getSelectedSlotIndex()
+    return self.selectedSlot
+end
+
+function SaveSlots:getSelectedSlotName()
+    if not self.selectedSlot then return nil end
+    return self._slotOrder[self.selectedSlot]
+end
+
+function SaveSlots:setSelectedSlot(index)
+    if index and index >= 1 and index <= #self._slotOrder then
+        self.selectedSlot = index
+    end
+end
+
+function SaveSlots:getPreferredSize()
+    local baseFont = Theme.fonts and Theme.fonts.normal or love.graphics.getFont()
+    local buttonFont = (Theme.fonts and (Theme.fonts.tiny or Theme.fonts.small)) or baseFont
+    local lineHeight = baseFont:getHeight() + 4
+    local _, buttonH = computeButtonSize(buttonFont, 18, 8, 105, buttonFont:getHeight() + 16, "Sample")
+    local slotHeight = lineHeight * 3 + buttonH + 24
+    local headerHeight = lineHeight * 6
+    local totalHeight = headerHeight + slotHeight * #self._slotOrder + lineHeight * 5
+    local preferredWidth = 380
+    return preferredWidth, totalHeight
+end
+
 function SaveSlots:draw(x, y, w, h)
+    self:_ensureCache()
+
     local baseFont = Theme.fonts and Theme.fonts.normal or love.graphics.getFont()
     local buttonFont = (Theme.fonts and (Theme.fonts.tiny or Theme.fonts.small)) or baseFont
     local buttonPaddingX, buttonPaddingY = 18, 8
-    local buttonMinWidth = 105
+    local buttonMinWidth = 120
     local buttonMinHeight = buttonFont:getHeight() + buttonPaddingY * 2
     local lineHeight = baseFont:getHeight() + 4
     local currentY = y + 10
     local layout = {
         saveButton = nil,
+        loadButton = nil,
         slots = {},
         autosaveLoad = nil
     }
     self._layout = layout
 
-    local function computeButtonSize(label)
-        local prevFont = love.graphics.getFont()
-        love.graphics.setFont(buttonFont)
-        local textW = buttonFont:getWidth(label)
-        local textH = buttonFont:getHeight()
-        love.graphics.setFont(prevFont)
-        local width = math.max(buttonMinWidth, textW + buttonPaddingX * 2)
-        local height = math.max(buttonMinHeight, textH + buttonPaddingY * 2)
-        return width, height, textW, textH
-    end
-
-    local function drawButtonRect(xPos, yPos, width, height, fillColor, label)
-        Theme.setColor(fillColor)
-        love.graphics.rectangle("fill", xPos, yPos, width, height)
-        Theme.setColor(Theme.colors.text)
-        local prevFont = love.graphics.getFont()
-        love.graphics.setFont(buttonFont)
-        local textW = buttonFont:getWidth(label)
-        local textH = buttonFont:getHeight()
-        local availableW = width - buttonPaddingX * 2
-        local availableH = height - buttonPaddingY * 2
-        if textW <= 0 or textH <= 0 then
-            love.graphics.print(label, xPos + buttonPaddingX, yPos + buttonPaddingY)
-            love.graphics.setFont(prevFont)
-            return
-        end
-        local scale = math.min(1, availableW / textW, availableH / textH)
-        if scale <= 0 then scale = availableH / textH end
-        local drawW = textW * scale
-        local drawH = textH * scale
-        local drawX = xPos + (width - drawW) / 2
-        local drawY = yPos + (height - drawH) / 2
-        love.graphics.print(label, drawX, drawY, 0, scale, scale)
-        love.graphics.setFont(prevFont)
-    end
-
-    -- Quick actions
+    -- Quick actions information
     Theme.setColor(Theme.colors.textSecondary)
     love.graphics.print("F5: Quick Save  |  F9: Quick Load", x + 10, currentY)
     currentY = currentY + lineHeight * 1.5
 
-    -- Auto-save status
-    local stats = StateManager.getStats()
+    local stats = StateManager.getStats() or {}
     local statusText = string.format("Auto-save: %s | Last save: %s",
         stats.autoSaveEnabled and "ON" or "OFF",
-        stats.lastSave)
+        stats.lastSave or "Never")
     love.graphics.print(statusText, x + 10, currentY)
     currentY = currentY + lineHeight * 2
 
-    -- New save section
+    -- Instructions
     Theme.setColor(Theme.colors.accent)
-    love.graphics.print("Create New Save:", x + 10, currentY)
+    love.graphics.print("Select a slot, then choose Save or Load:", x + 10, currentY)
+    currentY = currentY + lineHeight * 1.5
+
+    local saveLabel = "Save Game"
+    local loadLabel = "Load Game"
+    local saveButtonW, saveButtonH = computeButtonSize(buttonFont, buttonPaddingX, buttonPaddingY, buttonMinWidth, buttonMinHeight, saveLabel)
+    local loadButtonW, loadButtonH = computeButtonSize(buttonFont, buttonPaddingX, buttonPaddingY, buttonMinWidth, buttonMinHeight, loadLabel)
+    local buttonSpacing = 14
+    local buttonRowWidth = saveButtonW + loadButtonW + buttonSpacing
+    local buttonRowX = x + math.max(10, (w - buttonRowWidth) / 2)
+
+    local selectedSlotName = self:getSelectedSlotName()
+    local hasSelectedSlot = selectedSlotName ~= nil
+    local selectedSlotData = hasSelectedSlot and self._slotLookup[selectedSlotName] or nil
+
+    drawButtonRect(buttonFont, buttonPaddingX, buttonPaddingY, buttonRowX, currentY, saveButtonW, saveButtonH, Theme.colors.success, saveLabel, hasSelectedSlot)
+    layout.saveButton = { x = buttonRowX, y = currentY, w = saveButtonW, h = saveButtonH }
+
+    drawButtonRect(buttonFont, buttonPaddingX, buttonPaddingY, buttonRowX + saveButtonW + buttonSpacing, currentY, loadButtonW, loadButtonH, Theme.colors.info, loadLabel, selectedSlotData ~= nil)
+    layout.loadButton = { x = buttonRowX + saveButtonW + buttonSpacing, y = currentY, w = loadButtonW, h = loadButtonH }
+
+    currentY = currentY + math.max(saveButtonH, loadButtonH) + lineHeight * 1.5
+
+    -- Manual slots header
+    Theme.setColor(Theme.colors.accent)
+    love.graphics.print("Manual Slots:", x + 10, currentY)
     currentY = currentY + lineHeight
 
-    -- New save input (placeholder for now - would need proper text input)
-    Theme.setColor(Theme.colors.bg1)
-    love.graphics.rectangle("fill", x + 10, currentY, w - 20, lineHeight * 1.2)
-    Theme.setColor(Theme.colors.border)
-    love.graphics.rectangle("line", x + 10, currentY, w - 20, lineHeight * 1.2)
-
-    Theme.setColor(Theme.colors.textSecondary)
-    local saveName = self.newSaveName ~= "" and self.newSaveName or "Enter save name..."
-    local inputFont = buttonFont
-    local prevFont = love.graphics.getFont()
-    love.graphics.setFont(inputFont)
-    love.graphics.print(saveName, x + 15, currentY + (lineHeight * 1.2 - inputFont:getHeight()) / 2)
-    love.graphics.setFont(prevFont)
-    currentY = currentY + lineHeight * 2
-
-    -- Save button
-    local saveLabel = "Save"
-    local saveButtonW, saveButtonH = computeButtonSize(saveLabel)
-    drawButtonRect(x + 10, currentY, saveButtonW, saveButtonH, Theme.colors.success, saveLabel)
-    layout.saveButton = { x = x + 10, y = currentY, w = saveButtonW, h = saveButtonH }
-
-    currentY = currentY + saveButtonH + lineHeight
-
-    -- Existing saves
-    Theme.setColor(Theme.colors.accent)
-    love.graphics.print("Existing Saves:", x + 10, currentY)
-    currentY = currentY + lineHeight
-
-    -- List save slots
-    local slots = StateManager.getSaveSlots()
-
-    local loadLabel = "Load"
     local deleteLabel = "Delete"
-    local loadButtonW, loadButtonH = computeButtonSize(loadLabel)
-    local deleteButtonW, deleteButtonH = computeButtonSize(deleteLabel)
-    local slotButtonWidth = math.max(loadButtonW, deleteButtonW)
-    local slotButtonHeight = math.max(loadButtonH, deleteButtonH)
-    local slotPadding = math.max(12, buttonPaddingY + 2)
-    local buttonSpacing = math.max(10, buttonPaddingX * 0.5)
+    local deleteButtonW, deleteButtonH = computeButtonSize(buttonFont, buttonPaddingX, buttonPaddingY, math.max(105, loadButtonW), buttonMinHeight, deleteLabel)
+    local slotPadding = 14
+    local slotSpacing = 8
+    local slotContentPadding = 12
+    local slotHeight = lineHeight * 3 + deleteButtonH + slotPadding
 
-    if #slots == 0 then
-        Theme.setColor(Theme.colors.textSecondary)
-        love.graphics.print("No save files found", x + 10, currentY)
-    else
-        for i, slot in ipairs(slots) do
-            -- Skip auto-saves in main list (show them separately)
-            if slot.name ~= "autosave" then
-                local slotY = currentY
-                local slotH = lineHeight * 2.5
+    for index, slotName in ipairs(self._slotOrder) do
+        local slotY = currentY
+        local slotRect = { x = x + 10, y = slotY, w = w - 20, h = slotHeight }
+        local slotData = self._slotLookup[slotName]
+        local isSelected = (self.selectedSlot == index)
 
-                -- Background
-                local bgColor = (self.selectedSlot == slot.name) and Theme.colors.bg2 or Theme.colors.bg1
-                Theme.setColor(bgColor)
-                love.graphics.rectangle("fill", x + 10, slotY, w - 20, slotH)
-
-                -- Border
-                Theme.setColor(Theme.colors.border)
-                love.graphics.rectangle("line", x + 10, slotY, w - 20, slotH)
-
-                -- Slot info
-                Theme.setColor(Theme.colors.text)
-                love.graphics.print(slot.description or slot.name, x + 15, slotY + 4)
-
-                local infoText = string.format("Level %d | %d GC | %s",
-                    slot.playerLevel or 1,
-                    slot.playerCredits or 0,
-                    slot.realTime or "Unknown time")
-                Theme.setColor(Theme.colors.textSecondary)
-                love.graphics.print(infoText, x + 15, slotY + lineHeight + 2)
-
-                -- Load button
-                local buttonY = slotY + slotH - slotButtonHeight - slotPadding
-
-                local loadButtonX = x + w - slotPadding - slotButtonWidth
-                drawButtonRect(loadButtonX, buttonY, slotButtonWidth, slotButtonHeight, Theme.colors.info, loadLabel)
-
-                -- Delete button
-                local deleteButtonX = loadButtonX - buttonSpacing - slotButtonWidth
-                drawButtonRect(deleteButtonX, buttonY, slotButtonWidth, slotButtonHeight, Theme.colors.danger, deleteLabel)
-
-                layout.slots[slot.name] = {
-                    load = { x = loadButtonX, y = buttonY, w = slotButtonWidth, h = slotButtonHeight },
-                    delete = { x = deleteButtonX, y = buttonY, w = slotButtonWidth, h = slotButtonHeight }
-                }
-
-                currentY = currentY + slotH + 4
-            end
+        local bgColor
+        if isSelected then
+            bgColor = Theme.colors.bg2
+        elseif slotData then
+            bgColor = Theme.colors.bg1
+        else
+            bgColor = Theme.withAlpha(Theme.colors.bg1, 0.6)
         end
+        Theme.setColor(bgColor)
+        love.graphics.rectangle("fill", slotRect.x, slotRect.y, slotRect.w, slotRect.h)
+
+        local borderColor = isSelected and Theme.colors.accent or Theme.colors.border
+        Theme.setColor(borderColor)
+        love.graphics.rectangle("line", slotRect.x, slotRect.y, slotRect.w, slotRect.h)
+
+        Theme.setColor(Theme.colors.text)
+        love.graphics.print(string.format("Slot %d", index), slotRect.x + slotContentPadding, slotRect.y + 6)
+
+        if slotData then
+            Theme.setColor(Theme.colors.textSecondary)
+            love.graphics.print(slotData.description or "Manual Save", slotRect.x + slotContentPadding, slotRect.y + lineHeight + 4)
+            local infoText = string.format("Level %d | %d GC | %s",
+                slotData.playerLevel or 1,
+                slotData.playerCredits or 0,
+                slotData.realTime or "Unknown")
+            love.graphics.print(infoText, slotRect.x + slotContentPadding, slotRect.y + lineHeight * 2 + 4)
+        else
+            Theme.setColor(Theme.colors.textSecondary)
+            love.graphics.print("Empty slot", slotRect.x + slotContentPadding, slotRect.y + lineHeight + 4)
+            love.graphics.print("Click to select for saving", slotRect.x + slotContentPadding, slotRect.y + lineHeight * 2 + 4)
+        end
+
+        layout.slots[slotName] = {
+            body = slotRect,
+            index = index,
+            delete = nil
+        }
+
+        if slotData then
+            local deleteX = slotRect.x + slotRect.w - deleteButtonW - slotPadding
+            local deleteY = slotRect.y + slotRect.h - deleteButtonH - slotPadding
+            drawButtonRect(buttonFont, buttonPaddingX, buttonPaddingY, deleteX, deleteY, deleteButtonW, deleteButtonH, Theme.colors.danger, deleteLabel, true)
+            layout.slots[slotName].delete = { x = deleteX, y = deleteY, w = deleteButtonW, h = deleteButtonH }
+        end
+
+        currentY = currentY + slotHeight + slotSpacing
+    end
+
+    currentY = currentY + lineHeight
+
+    -- Quick save card if available
+    local quicksave = self._slotLookup and self._slotLookup["quicksave"] or nil
+    if quicksave then
+        Theme.setColor(Theme.colors.accent)
+        love.graphics.print("Quick Save:", x + 10, currentY)
+        currentY = currentY + lineHeight
+
+        local quickHeight = lineHeight * 2 + deleteButtonH + slotPadding
+        local quickRect = { x = x + 10, y = currentY, w = w - 20, h = quickHeight }
+        Theme.setColor(Theme.colors.bg1)
+        love.graphics.rectangle("fill", quickRect.x, quickRect.y, quickRect.w, quickRect.h)
+        Theme.setColor(Theme.colors.border)
+        love.graphics.rectangle("line", quickRect.x, quickRect.y, quickRect.w, quickRect.h)
+
+        Theme.setColor(Theme.colors.text)
+        love.graphics.print(quicksave.description or "Quick Save", quickRect.x + slotContentPadding, quickRect.y + 6)
+        Theme.setColor(Theme.colors.textSecondary)
+        love.graphics.print(string.format("Level %d | %d GC | %s",
+            quicksave.playerLevel or 1,
+            quicksave.playerCredits or 0,
+            quicksave.realTime or "Unknown"), quickRect.x + slotContentPadding, quickRect.y + lineHeight + 4)
+
+        currentY = currentY + quickHeight + slotSpacing
     end
 
     -- Auto-save section (at bottom)
-    currentY = currentY + lineHeight
     Theme.setColor(Theme.colors.warning)
     love.graphics.print("Auto-Save:", x + 10, currentY)
     currentY = currentY + lineHeight
 
-    -- Find autosave slot
-    local autosave = nil
-    for _, slot in ipairs(slots) do
-        if slot.name == "autosave" then
-            autosave = slot
-            break
-        end
-    end
-
+    local autosave = self._slotLookup and self._slotLookup["autosave"] or nil
     if autosave then
-        local autosaveY = currentY
-        local autosaveH = math.max(lineHeight * 2, slotButtonHeight + slotPadding * 2)
+        local autosaveH = math.max(lineHeight * 2, deleteButtonH + slotPadding * 2)
+        local autosaveRect = { x = x + 10, y = currentY, w = w - 20, h = autosaveH }
 
         Theme.setColor(Theme.colors.bg1)
-        love.graphics.rectangle("fill", x + 10, autosaveY, w - 20, autosaveH)
+        love.graphics.rectangle("fill", autosaveRect.x, autosaveRect.y, autosaveRect.w, autosaveRect.h)
         Theme.setColor(Theme.colors.border)
-        love.graphics.rectangle("line", x + 10, autosaveY, w - 20, autosaveH)
+        love.graphics.rectangle("line", autosaveRect.x, autosaveRect.y, autosaveRect.w, autosaveRect.h)
 
         Theme.setColor(Theme.colors.text)
-        love.graphics.print("Auto-save " .. (autosave.realTime or "Unknown"), x + 15, autosaveY + 4)
+        love.graphics.print("Auto-save " .. (autosave.realTime or "Unknown"), autosaveRect.x + slotContentPadding, autosaveRect.y + 6)
 
         local autoInfo = string.format("Level %d | %d GC",
             autosave.playerLevel or 1,
             autosave.playerCredits or 0)
         Theme.setColor(Theme.colors.textSecondary)
-        love.graphics.print(autoInfo, x + 15, autosaveY + lineHeight + 2)
+        love.graphics.print(autoInfo, autosaveRect.x + slotContentPadding, autosaveRect.y + lineHeight + 4)
 
-        -- Auto-save load button
-        local buttonY = autosaveY + autosaveH - slotButtonHeight - slotPadding
-        local autoLoadButtonX = x + w - slotPadding - slotButtonWidth
-        drawButtonRect(autoLoadButtonX, buttonY, slotButtonWidth, slotButtonHeight, Theme.colors.warning, loadLabel)
-        layout.autosaveLoad = { x = autoLoadButtonX, y = buttonY, w = slotButtonWidth, h = slotButtonHeight }
+        local buttonY = autosaveRect.y + autosaveRect.h - deleteButtonH - slotPadding
+        local autoLoadButtonX = autosaveRect.x + autosaveRect.w - deleteButtonW - slotPadding
+        drawButtonRect(buttonFont, buttonPaddingX, buttonPaddingY, autoLoadButtonX, buttonY, deleteButtonW, deleteButtonH, Theme.colors.warning, loadLabel, true)
+        layout.autosaveLoad = { x = autoLoadButtonX, y = buttonY, w = deleteButtonW, h = deleteButtonH }
     else
         Theme.setColor(Theme.colors.textSecondary)
         love.graphics.print("No auto-save available", x + 10, currentY)
     end
 end
 
+local function pointInRect(px, py, rect)
+    if not rect then return false end
+    return px >= rect.x and px <= rect.x + rect.w and py >= rect.y and py <= rect.y + rect.h
+end
+
 function SaveSlots:mousepressed(mx, my, button)
     if button ~= 1 then return false end
 
+    self:_ensureCache()
     local layout = self._layout or {}
+    local selectedSlotName = self:getSelectedSlotName()
+    local selectedData = selectedSlotName and self._slotLookup and self._slotLookup[selectedSlotName] or nil
 
-    local function pointInRect(px, py, rect)
-        if not rect then return false end
-        return px >= rect.x and px <= rect.x + rect.w and py >= rect.y and py <= rect.y + rect.h
-    end
-
-    -- Save button
     if pointInRect(mx, my, layout.saveButton) then
-        -- Create new save with current timestamp as name
-        local saveName = self.newSaveName ~= "" and self.newSaveName or ("Save " .. os.date("%H%M%S"))
-        StateManager.saveGame(saveName, "Manual save - " .. os.date("%Y-%m-%d %H:%M:%S"))
-        return true
+        if not selectedSlotName then
+            return "noop"
+        end
+
+        local description = string.format("Manual save - %s", os.date("%Y-%m-%d %H:%M:%S"))
+        local success = StateManager.saveGame(selectedSlotName, description)
+        if success then
+            self._cacheDirty = true
+            return "saved"
+        end
+        return "saveFailed"
     end
 
-    -- Check save slots for load/delete buttons
+    if pointInRect(mx, my, layout.loadButton) then
+        if not selectedSlotName or not selectedData then
+            return "noop"
+        end
+        local loaded = StateManager.loadGame(selectedSlotName)
+        if loaded then
+            self._cacheDirty = true
+            return "loaded"
+        end
+        return "loadFailed"
+    end
+
     if layout.slots then
         for slotName, rects in pairs(layout.slots) do
-            if pointInRect(mx, my, rects.load) then
-                StateManager.loadGame(slotName)
-                return true
-            end
             if pointInRect(mx, my, rects.delete) then
-                StateManager.deleteSave(slotName)
-                return true
+                local deleted = StateManager.deleteSave(slotName)
+                if deleted then
+                    if self:getSelectedSlotName() == slotName then
+                        -- Keep selection on the slot index so player can immediately save again
+                        self._cacheDirty = true
+                    else
+                        self._cacheDirty = true
+                    end
+                    return "deleted"
+                end
+                return "deleteFailed"
+            end
+
+            if pointInRect(mx, my, rects.body) then
+                if rects.index then
+                    self:setSelectedSlot(rects.index)
+                    return "selected"
+                end
             end
         end
     end
 
     if pointInRect(mx, my, layout.autosaveLoad) then
-        StateManager.loadGame("autosave")
-        return true
-    end
-
-    return false
-end
-
-function SaveSlots:textinput(text)
-    -- Simple text input for save name
-    if text and text:match("[%w%s%-_]") then
-        if #self.newSaveName < 30 then
-            self.newSaveName = self.newSaveName .. text
+        local loaded = StateManager.loadGame("autosave")
+        if loaded then
+            return "autosaveLoaded"
         end
-        return true
+        return "loadFailed"
     end
+
     return false
 end
 
-function SaveSlots:keypressed(key)
-    if key == "backspace" and #self.newSaveName > 0 then
-        self.newSaveName = self.newSaveName:sub(1, -2)
-        return true
-    end
+function SaveSlots:textinput(_)
+    return false
+end
+
+function SaveSlots:keypressed(_)
     return false
 end
 


### PR DESCRIPTION
## Summary
- convert the save/load panel to numbered save slots with explicit save/load controls and metadata
- adjust the escape menu window handling so newly opened panels float to the front and consume input correctly
- update start screen loading to use the selected slot index for launching saved games

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d97b33374c8322a4dca34ec5b36497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2e6596bcc90382f75588656ec30b87b236629ab8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->