### PR TITLE
Fix Respawn Player Movement Regression

### DIFF
--- a/src/core/physics.lua
+++ b/src/core/physics.lua
@@ -283,6 +283,16 @@ function PhysicsBody:setVelocity(vx, vy)
     self.vy = vy
 end
 
+-- Explicitly set position (for compatibility with systems that reposition bodies directly)
+function PhysicsBody:setPosition(x, y)
+    if x ~= nil then
+        self.x = x
+    end
+    if y ~= nil then
+        self.y = y
+    end
+end
+
 -- Apply impulse (instant change in momentum)
 function PhysicsBody:applyImpulse(ix, iy)
     self.vx = self.vx + ix / self.mass


### PR DESCRIPTION
## Summary
- add a PhysicsBody:setPosition helper so respawn logic can safely reposition the player without clearing their body reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68daa52a6c388322b69439cacb473a34