### PR TITLE
Restore Player Thruster Tuning After Respawn

### DIFF
--- a/src/core/physics.lua
+++ b/src/core/physics.lua
@@ -283,6 +283,16 @@ function PhysicsBody:setVelocity(vx, vy)
     self.vy = vy
 end
 
+-- Explicitly set position (for compatibility with systems that reposition bodies directly)
+function PhysicsBody:setPosition(x, y)
+    if x ~= nil then
+        self.x = x
+    end
+    if y ~= nil then
+        self.y = y
+    end
+end
+
 -- Apply impulse (instant change in momentum)
 function PhysicsBody:applyImpulse(ix, iy)
     self.vx = self.vx + ix / self.mass


### PR DESCRIPTION
## Summary
- add a respawn helper that reapplies the player ship's engine tuning to new physics bodies
- clear all linear and angular acceleration terms when rebuilding or resetting the player's physics body to avoid residual forces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68daa52a6c388322b69439cacb473a34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores player engine-based physics tuning on respawn, clears acceleration/torque, resets thrusters, and adds PhysicsBody:setPosition for safe repositioning.
> 
> - **Gameplay/Systems**:
>   - **Respawn flow (player)**:
>     - Recreate/validate physics body, set position via `phys.body:setPosition(px, py)`, and ensure awake/active.
>     - Clear linear/angular acceleration terms: `ax`, `ay`, `torque` set to `0` on create and reset.
>     - Restore engine-based tuning via `restorePlayerPhysicsTuning` (mass, thruster power, `maxSpeed`, `dragCoefficient`, `radius`).
>     - Reset thrusters, set `boostFactor = 1.0`, zero angular/linear velocities.
>   - **Loot/Effects/Events**: No functional changes beyond existing flow; logs improved for debugging.
> - **Core Physics**:
>   - Add `PhysicsBody:setPosition(x, y)` for explicit repositioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d21a43d22f63bff2c98a085690edf55967eaa531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->