### PR TITLE
Set Logger To Info Level During Load

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -112,19 +112,15 @@ local function seedRandom()
 end
 
 function love.load()
-    local Log = require('src/core/log')
+    local Log = require("src.core.log")
+    Log.setLevel("info")
+    Log.setInfoEnabled(true) -- Ensure info-level logs are emitted during startup
+    Log.clearDebugWhitelist()
     Log.info("Game Identity:", love.filesystem.getIdentity())
     Log.info("LÖVE Save Directory:", love.filesystem.getSaveDirectory())
-    Log.setLevel('debug')
-    Log.clearDebugWhitelist()
     seedRandom()
     Settings.load()
     Sound.applySettings()
-
-    local Log = require("src.core.log")
-    Log.setLevel("warn")
-    Log.setDebugWhitelist(nil)
-    Log.setInfoEnabled(true) -- Enable info logs for better feedback
 
     local SettingsModule = require("src.core.settings")
     local km = SettingsModule.getKeymap() or {}


### PR DESCRIPTION
## Summary
- initialize the logger once during `love.load` at the info level so startup logs emit
- remove the redundant re-require and align the inline comment with the new logging behavior

## Testing
- ⚠️ `lua - <<'EOF'` *(fails: `lua` interpreter is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dab2c127588322b37713f80050a3e6