### PR TITLE
Centralize Combat And Spawn Constants

### DIFF
--- a/src/content/config.lua
+++ b/src/content/config.lua
@@ -1,26 +1,15 @@
+local Constants = require("src.core.constants")
+
 local Config = {}
 
--- Global gameplay/config constants
-Config.MAX_ENEMIES = 12
+Config.WORLD = Constants.WORLD
 
-Config.WORLD = {
-  WIDTH = 30000,
-  HEIGHT = 30000,
-}
-
-Config.SPAWN = {
-  MARGIN = 75,             -- keep spawns away from world edges (scaled for smaller world)
-  STATION_BUFFER = 5000,   -- safe zone radius around all stations (no enemy spawns)
-  PLAYER_SPAWN_BUFFER = 100, -- buffer for spawning player near the station
-  MIN_PLAYER_DIST = 150,   -- min distance from player for new enemy spawns (scaled for smaller world)
-  INTERVAL_MIN = 2.0,      -- seconds
-  INTERVAL_MAX = 4.0,      -- seconds
-
+Config.SPAWN = setmetatable({
   -- Custom no-spawn zones (areas where enemies should never spawn)
   -- Note: Now handled by beacon stations with custom no_spawn_radius property
   NO_SPAWN_ZONES = {
   }
-}
+}, { __index = Constants.SPAWNING })
 
 Config.MISSILE = {
   EXPLODE_RADIUS = 48,
@@ -39,30 +28,10 @@ Config.BULLET = {
 }
 
 -- Player combat tuning
-Config.COMBAT = {
-  -- Alignment lock: player must face target within this cone to allow firing
-  ALIGN_LOCK_DEG = 10,        -- degrees
-  ALIGN_RANGE_BONUS = 1.2,    -- allow a bit beyond optimal range when well aligned
-
-  -- Boost: sustained thrust multiplier with energy drain (replaces dash)
-  BOOST_THRUST_MULT = 1.5,   -- thrust multiplier while boosting
-  BOOST_ENERGY_DRAIN = 100,    -- energy per second while boosting
-
-  -- Shield active ability: 50% damage reduction with duration/cooldown system
-  SHIELD_CHANNEL_SLOW = 0.5,    -- movement/thrust multiplier while active
-  SHIELD_DAMAGE_REDUCTION = 0.5, -- 50% damage reduction when active
-  SHIELD_DURATION = 3.0,        -- duration in seconds
-  SHIELD_COOLDOWN = 5.0,        -- cooldown in seconds
-  SHIELD_ENERGY_COST = 50,      -- energy cost per activation
-
-  -- HUD visibility windows
-  ENEMY_BAR_VIS_TIME = 2.5,   -- seconds after player damage
-
-  -- No parry/directional multipliers in simple manual mode
-}
+Config.COMBAT = Constants.COMBAT
 
 Config.HUB = {
-  WEAPONS_DISABLE_DURATION = 5.0,  -- seconds weapons stay disabled after leaving hub range
+  WEAPONS_DISABLE_DURATION = Constants.STATION.WEAPONS_DISABLE_DURATION,
 }
 
 -- Quest system settings
@@ -82,13 +51,6 @@ Config.RENDER = {
 }
 
 -- Audio behavior
-Config.AUDIO = {
-  -- Within this distance (world units), play SFX at full event volume
-  FULL_VOLUME_DISTANCE = 300,
-  -- Beyond this distance, SFX are inaudible
-  HEARING_DISTANCE = 1400,
-  -- Minimum volume multiplier when attenuated (0 = hard cutoff)
-  MIN_VOLUME = 0.0,
-}
+Config.AUDIO = Constants.AUDIO
 
 return Config

--- a/src/core/constants.lua
+++ b/src/core/constants.lua
@@ -147,28 +147,32 @@ Constants.WORLD = {
 
 Constants.COMBAT = {
     -- Alignment and targeting
-    ALIGN_LOCK_DEGREES = 10,
+    ALIGN_LOCK_DEG = 10,
     ALIGN_RANGE_BONUS = 1.2,
 
     -- Boost mechanics
-    BOOST_THRUST_MULTIPLIER = 1.5,
-    BOOST_ENERGY_DRAIN_PER_SECOND = 100,
+    BOOST_THRUST_MULT = 1.5,
+    BOOST_ENERGY_DRAIN = 100,
 
     -- Shield ability
-    SHIELD_CHANNEL_SLOWDOWN = 0.5,
+    SHIELD_CHANNEL_SLOW = 0.5,
     SHIELD_DAMAGE_REDUCTION = 0.5,
     SHIELD_DURATION = 3.0,
     SHIELD_COOLDOWN = 5.0,
     SHIELD_ENERGY_COST = 50,
 
+    -- Collision restitution
+    HULL_RESTITUTION = 0.28,
+    SHIELD_RESTITUTION = 0.88,
+
     -- HUD visibility
-    ENEMY_BAR_VISIBLE_TIME = 2.5,
+    ENEMY_BAR_VIS_TIME = 2.5,
 }
 
 Constants.SPAWNING = {
     MARGIN = 75,
-    STATION_BUFFER = 300,
-    MIN_PLAYER_DISTANCE = 150,
+    STATION_BUFFER = 5000,
+    MIN_PLAYER_DIST = 150,
     INTERVAL_MIN = 2.0,
     INTERVAL_MAX = 4.0,
     MAX_ENEMIES = 36,

--- a/src/core/sound.lua
+++ b/src/core/sound.lua
@@ -5,6 +5,7 @@
 
 local Settings = require("src.core.settings")
 local Log = require("src.core.log")
+local Constants = require("src.core.constants")
 local Config = require("src.content.config")
 local Sound = {}
 local SoundGenerator = require("src.core.sound_generator")
@@ -22,11 +23,12 @@ local listenerX, listenerY = nil, nil
 
 -- Audio attenuation settings (can be overridden via Config.AUDIO)
 local function getAudioConfig()
-    local A = (Config and Config.AUDIO) or {}
+    local overrides = (Config and Config.AUDIO) or {}
+    local defaults = Constants.AUDIO
     return {
-        FULL_VOLUME_DISTANCE = A.FULL_VOLUME_DISTANCE or 300,  -- within this distance play at event volume
-        HEARING_DISTANCE = A.HEARING_DISTANCE or 1400,         -- beyond this distance: silent
-        MIN_VOLUME = A.MIN_VOLUME or 0.0                       -- floor volume multiplier (0..1)
+        FULL_VOLUME_DISTANCE = overrides.FULL_VOLUME_DISTANCE or defaults.FULL_VOLUME_DISTANCE,
+        HEARING_DISTANCE = overrides.HEARING_DISTANCE or defaults.HEARING_DISTANCE,
+        MIN_VOLUME = overrides.MIN_VOLUME or defaults.MIN_VOLUME
     }
 end
 

--- a/src/game.lua
+++ b/src/game.lua
@@ -219,7 +219,8 @@ function Game.load(fromSave, saveSlot, loadingScreen)
 
   -- Step 9: Spawn the player
   updateProgress(0.9, "Spawning player...")
-  local spawn_margin = assert(Config.SPAWN and Config.SPAWN.STATION_BUFFER, "Config.SPAWN.STATION_BUFFER is required") or Constants.SPAWNING.STATION_BUFFER
+  local spawnSettings = Config.SPAWN or {}
+  local spawn_margin = spawnSettings.STATION_BUFFER or Constants.SPAWNING.STATION_BUFFER
 
   -- Handle loading from save vs starting new game
   if fromSave and saveSlot then

--- a/src/systems/collision/entity_collision.lua
+++ b/src/systems/collision/entity_collision.lua
@@ -1,3 +1,4 @@
+local Constants = require("src.core.constants")
 local Config = require("src.content.config")
 local Effects = require("src.systems.effects")
 local Radius = require("src.systems.collision.radius")
@@ -5,6 +6,15 @@ local StationShields = require("src.systems.collision.station_shields")
 local CollisionEffects = require("src.systems.collision.effects")
 
 local EntityCollision = {}
+
+local combatOverrides = Config.COMBAT or {}
+local combatConstants = Constants.COMBAT
+
+local function getCombatValue(key)
+    local value = combatOverrides[key]
+    if value ~= nil then return value end
+    return combatConstants[key]
+end
 
 -- Check if two entities collide (using effective radius that includes shields)
 local function checkEntityCollision(entity1, entity2)
@@ -140,8 +150,8 @@ function EntityCollision.resolveEntityCollision(entity1, entity2, dt)
         local pushDistance = overlap * 0.55 -- Split the separation
 
         -- Choose restitution based on shields (make shields bouncier)
-        local HULL_REST = (Config and Config.COMBAT and Config.COMBAT.HULL_RESTITUTION) or 0.28
-        local SHIELD_REST = (Config and Config.COMBAT and Config.COMBAT.SHIELD_RESTITUTION) or 0.88
+        local HULL_REST = getCombatValue("HULL_RESTITUTION") or 0.28
+        local SHIELD_REST = getCombatValue("SHIELD_RESTITUTION") or 0.88
         local e1Rest = StationShields.hasActiveShield(entity1) and SHIELD_REST or HULL_REST
         local e2Rest = StationShields.hasActiveShield(entity2) and SHIELD_REST or HULL_REST
 

--- a/src/ui/hud/enemy_status_bars.lua
+++ b/src/ui/hud/enemy_status_bars.lua
@@ -1,4 +1,15 @@
 local Theme = require("src.core.theme")
+local Constants = require("src.core.constants")
+local Config = require("src.content.config")
+
+local combatOverrides = Config.COMBAT or {}
+local combatConstants = Constants.COMBAT
+
+local function getCombatValue(key)
+  local value = combatOverrides[key]
+  if value ~= nil then return value end
+  return combatConstants[key]
+end
 local EnemyStatusBars = {}
 
 -- Draw small screen-aligned shield/health bars above an enemy entity.
@@ -9,7 +20,7 @@ function EnemyStatusBars.drawMiniBars(entity)
   if not (h and col) then return end
 
   -- Only show for a limited duration after player deals damage
-  local showTime = (require("src.content.config").COMBAT.ENEMY_BAR_VIS_TIME or 2.5)
+  local showTime = getCombatValue("ENEMY_BAR_VIS_TIME") or 2.5
   local last = entity._hudDamageTime or -1e9
   if love.timer.getTime() - last > showTime then return end
 

--- a/src/ui/hud/hotbar.lua
+++ b/src/ui/hud/hotbar.lua
@@ -2,9 +2,19 @@ local Theme = require("src.core.theme")
 local Viewport = require("src.core.viewport")
 local Content = require("src.content.content")
 local HotbarSystem = require("src.systems.hotbar")
+local Constants = require("src.core.constants")
 local Config = require("src.content.config")
 
 local Hotbar = {}
+
+local combatOverrides = Config.COMBAT or {}
+local combatConstants = Constants.COMBAT
+
+local function getCombatValue(key)
+  local value = combatOverrides[key]
+  if value ~= nil then return value end
+  return combatConstants[key]
+end
 
 -- HotbarSelection removed - slot assignment disabled
 
@@ -176,7 +186,7 @@ function Hotbar.draw(player)
       if slot.item == 'shield' then
         local ss = player._shieldState
         if ss and ss.cooldown and ss.cooldown > 0 then
-          local total = (Config.COMBAT and Config.COMBAT.SHIELD_COOLDOWN) or 5.0
+          local total = getCombatValue("SHIELD_COOLDOWN") or 5.0
           if total > 0 then
             local pct = math.max(0, math.min(1, ss.cooldown / total))
             local barHeight = math.floor(size * pct)

--- a/src/ui/hud/reticle.lua
+++ b/src/ui/hud/reticle.lua
@@ -1,6 +1,16 @@
 local Theme = require("src.core.theme")
 local Viewport = require("src.core.viewport")
+local Constants = require("src.core.constants")
 local Config = require("src.content.config")
+
+local combatOverrides = Config.COMBAT or {}
+local combatConstants = Constants.COMBAT
+
+local function getCombatValue(key)
+  local value = combatOverrides[key]
+  if value ~= nil then return value end
+  return combatConstants[key]
+end
 local Settings = require("src.core.settings")
 
 local Reticle = {}
@@ -15,7 +25,7 @@ local function isAligned(player)
   local desired = (math.atan2 and math.atan2(dy, dx)) or math.atan(dy / math.max(1e-6, dx))
   local diff = (desired - (pos.angle or 0) + math.pi) % (2 * math.pi) - math.pi
   local deg = math.deg(math.abs(diff))
-  return deg <= ((Config.COMBAT and Config.COMBAT.ALIGN_LOCK_DEG) or 10)
+  return deg <= (getCombatValue("ALIGN_LOCK_DEG") or 10)
 end
 
 function Reticle.drawPreset(style, scale, color)


### PR DESCRIPTION
## Summary
- re-export world, spawn, combat, and audio values from `Constants` so config no longer duplicates numbers
- update spawning, player, collision, HUD, and sound systems to read gameplay tuning from the centralized constants
- keep station safety margins and HUD timings consistent while allowing content overrides via helper accessors

## Testing
- not run (Love2D runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68dab2e139648322ab3cc3331a177c4e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes combat/spawn/audio/world tuning in `src/core/constants` and updates config and systems to consume these constants with content-level overrides.
> 
> - **Core**:
>   - Aligns `Constants.COMBAT`/`SPAWNING` keys with config names; adds `HULL_RESTITUTION`/`SHIELD_RESTITUTION` and adjusts defaults (e.g., `STATION_BUFFER=5000`).
> - **Config**:
>   - Re-exports `WORLD`, `COMBAT`, `AUDIO`, and `SPAWN` from `Constants` (with `NO_SPAWN_ZONES`), enabling content overrides via metatable.
> - **Systems**:
>   - **Player/Reticle/HUD**: Read combat values (`BOOST_THRUST_MULT`, `BOOST_ENERGY_DRAIN`, `SHIELD_CHANNEL_SLOW`, `SHIELD_COOLDOWN`, `ALIGN_LOCK_DEG`, `ENEMY_BAR_VIS_TIME`) via helper accessors.
>   - **Collision**: Use `HULL_RESTITUTION`/`SHIELD_RESTITUTION` from `Constants` with overrides.
>   - **Spawning**: Centralize spawn tuning (`MARGIN`, `STATION_BUFFER`, `MIN_PLAYER_DIST`, `INTERVAL_*`, `MAX_ENEMIES`) and no-spawn zones; derive all timings/margins from constants.
>   - **Sound**: Use `Constants.AUDIO` as defaults with `Config.AUDIO` overrides.
> - **Game**:
>   - Simplifies spawn margin selection using `Config.SPAWN` with `Constants` fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb4f24d2c1ac915c543e8795f0484dbabdb99855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->