### PR TITLE
Centralize UI PointInRect Helper

### DIFF
--- a/src/ui/bounty.lua
+++ b/src/ui/bounty.lua
@@ -2,6 +2,7 @@ local Theme = require("src.core.theme")
 local Viewport = require("src.core.viewport")
 local AuroraTitle = require("src.shaders.aurora_title")
 local Window = require("src.ui.common.window")
+local UIUtils = require("src.ui.common.utils")
 
 local Bounty = {
   visible = false,
@@ -30,14 +31,6 @@ end
 function Bounty.getRect()
     if not Bounty.window then return nil end
     return { x = Bounty.window.x, y = Bounty.window.y, w = Bounty.window.width, h = Bounty.window.height }
-end
-
-local function pointInRect(px, py, x, y, w, h)
-  -- Handle nil values gracefully
-  if px == nil or py == nil or x == nil or y == nil or w == nil or h == nil then
-    return false
-  end
-  return px >= x and py >= y and px <= x + w and py <= y + h
 end
 
 -- Icon drawing functions
@@ -77,7 +70,7 @@ local function drawClaimButton(docked)
     if not docked then return end
     local rect = getClaimButtonRect()
     local mx, my = Viewport.getMousePosition()
-    local hover = pointInRect(mx, my, rect.x, rect.y, rect.w, rect.h)
+    local hover = UIUtils.pointInRect(mx, my, rect)
     
     -- Use Theme functions for consistent button styling
     local buttonBg = hover and Theme.colors.primary or Theme.colors.bg2
@@ -212,12 +205,12 @@ function Bounty.mousepressed(x, y, button, docked)
     if Bounty._scrollbarTrack and Bounty._scrollbarThumb then
         local tr = Bounty._scrollbarTrack
         local th = Bounty._scrollbarThumb
-        if pointInRect(x, y, th.x, th.y, th.w, th.h) then
+        if UIUtils.pointInRect(x, y, th) then
             Bounty.dragging = "scrollbar"
             Bounty.dragDY = y - th.y
             return true, false
         end
-        if pointInRect(x, y, tr.x, tr.y, tr.w, tr.h) then
+        if UIUtils.pointInRect(x, y, tr) then
             local innerH = Bounty.window.height - (Bounty.window.titleBarHeight + (docked and 40 or 10))
             local trackRange = tr.h - th.h
             local rel = math.max(0, math.min(trackRange, (y - tr.y) - th.h * 0.5))
@@ -231,7 +224,7 @@ function Bounty.mousepressed(x, y, button, docked)
     -- Claim button
     if docked then
         local claimRect = getClaimButtonRect()
-        if pointInRect(x, y, claimRect.x, claimRect.y, claimRect.w, claimRect.h) then
+        if UIUtils.pointInRect(x, y, claimRect) then
             Bounty.claimDown = true
             return true, false
         end
@@ -256,7 +249,7 @@ function Bounty.mousereleased(x, y, button, docked, claimBounty)
         end
         if docked and Bounty.claimDown then
             local claimRect = getClaimButtonRect()
-            if pointInRect(x, y, claimRect.x, claimRect.y, claimRect.w, claimRect.h) then
+            if UIUtils.pointInRect(x, y, claimRect) then
                 if claimBounty then claimBounty() end
             end
             Bounty.claimDown = false

--- a/src/ui/common/utils.lua
+++ b/src/ui/common/utils.lua
@@ -77,8 +77,46 @@ function UIUtils.shouldUpdate(name, frequency)
 end
 
 -- Check if point is in rectangle
-function UIUtils.pointInRect(px, py, rect)
-  return px >= rect.x and py >= rect.y and px <= rect.x + rect.w and py <= rect.y + rect.h
+function UIUtils.pointInRect(px, py, rectOrX, y, w, h, options)
+  if px == nil or py == nil then
+    return false
+  end
+
+  local rect = rectOrX
+  local opts = options
+
+  if type(rectOrX) ~= "table" then
+    rect = {
+      x = rectOrX,
+      y = y,
+      w = w,
+      h = h,
+    }
+  elseif type(y) == "table" and options == nil and w == nil and h == nil then
+    opts = y
+  end
+
+  if not rect or rect.x == nil or rect.y == nil or rect.w == nil or rect.h == nil then
+    return false
+  end
+
+  local inclusive = true
+  if type(opts) == "table" then
+    if opts.inclusive ~= nil then
+      inclusive = opts.inclusive
+    end
+  elseif type(opts) == "boolean" then
+    inclusive = opts
+  end
+
+  local right = rect.x + rect.w
+  local bottom = rect.y + rect.h
+
+  if inclusive then
+    return px >= rect.x and px <= right and py >= rect.y and py <= bottom
+  end
+
+  return px >= rect.x and px < right and py >= rect.y and py < bottom
 end
 
 -- Create a button with hover states

--- a/src/ui/hud/hotbar.lua
+++ b/src/ui/hud/hotbar.lua
@@ -16,17 +16,6 @@ local function getCombatValue(key)
   return combatConstants[key]
 end
 
--- HotbarSelection removed - slot assignment disabled
-
-local function pointInRect(px, py, r)
-  -- Handle nil values gracefully
-  if px == nil or py == nil or r == nil or r.x == nil or r.y == nil or r.w == nil or r.h == nil then
-    return false
-  end
-  return px >= r.x and py >= r.y and px <= r.x + r.w and py <= r.y + r.h
-end
-
-
 local IconSystem = require("src.core.icon_system")
 
 local function drawIcon(subjects, x, y, size)

--- a/src/ui/save_slots.lua
+++ b/src/ui/save_slots.lua
@@ -1,5 +1,6 @@
 local Theme = require("src.core.theme")
 local StateManager = require("src.managers.state_manager")
+local UIUtils = require("src.ui.common.utils")
 
 local DEFAULT_SLOT_COUNT = 3
 
@@ -374,11 +375,6 @@ function SaveSlots:draw(x, y, w, h)
     end
 end
 
-local function pointInRect(px, py, rect)
-    if not rect then return false end
-    return px >= rect.x and px <= rect.x + rect.w and py >= rect.y and py <= rect.y + rect.h
-end
-
 function SaveSlots:mousepressed(mx, my, button)
     if button ~= 1 then return false end
 
@@ -387,7 +383,7 @@ function SaveSlots:mousepressed(mx, my, button)
     local selectedSlotName = self:getSelectedSlotName()
     local selectedData = selectedSlotName and self._slotLookup and self._slotLookup[selectedSlotName] or nil
 
-    if pointInRect(mx, my, layout.saveButton) then
+    if UIUtils.pointInRect(mx, my, layout.saveButton) then
         if self.disableSave then
             return "noop" -- Save button is disabled
         end
@@ -443,7 +439,7 @@ function SaveSlots:mousepressed(mx, my, button)
         end
     end
 
-    if pointInRect(mx, my, layout.loadButton) then
+    if UIUtils.pointInRect(mx, my, layout.loadButton) then
         if not selectedSlotName then
             local Notifications = require("src.ui.notifications")
             Notifications.add("Please select a slot first", "warning")
@@ -477,7 +473,7 @@ function SaveSlots:mousepressed(mx, my, button)
 
     if layout.slots then
         for slotName, rects in pairs(layout.slots) do
-            if pointInRect(mx, my, rects.delete) then
+            if UIUtils.pointInRect(mx, my, rects.delete) then
                 local deleted = StateManager.deleteSave(slotName)
                 if deleted then
                     if self:getSelectedSlotName() == slotName then
@@ -500,7 +496,7 @@ function SaveSlots:mousepressed(mx, my, button)
                 return "deleteFailed"
             end
 
-            if pointInRect(mx, my, rects.body) then
+            if UIUtils.pointInRect(mx, my, rects.body) then
                 if rects.index then
                     self:setSelectedSlot(rects.index)
                     return "selected"
@@ -509,7 +505,7 @@ function SaveSlots:mousepressed(mx, my, button)
         end
     end
 
-    if pointInRect(mx, my, layout.autosaveLoad) then
+    if UIUtils.pointInRect(mx, my, layout.autosaveLoad) then
         local success, error = pcall(StateManager.loadGame, "autosave")
         if success and error then
             -- Mark cache as dirty - it will refresh on next draw call

--- a/src/ui/ship.lua
+++ b/src/ui/ship.lua
@@ -1,15 +1,7 @@
 local Window = require("src.ui.common.window")
+local UIUtils = require("src.ui.common.utils")
 
 local Ship = {}
-
--- Helper function to check if point is inside rectangle
-local function pointInRect(px, py, rect)
-  -- Handle nil values gracefully
-  if px == nil or py == nil or rect == nil or rect.x == nil or rect.y == nil or rect.w == nil or rect.h == nil then
-    return false
-  end
-  return px >= rect.x and px < rect.x + rect.w and py >= rect.y and py < rect.y + rect.h
-end
 
 local function clamp(value, minValue, maxValue)
     if value < minValue then
@@ -171,10 +163,6 @@ local function buildHotbarPreview(player, gridOverride)
     end
 
     return preview
-end
-
-local function pointInRectSimple(px, py, rect)
-    return rect and px and py and px >= rect.x and px <= rect.x + rect.w and py >= rect.y and py <= rect.y + rect.h
 end
 
 function Ship:new()
@@ -655,7 +643,7 @@ function Ship:draw(player, x, y, w, h)
             local rowRectW = slotClipW - 4
             local rowRectH = math.max(36, labelHeight + dropdown.optionHeight + extraHotbarHeight + 16)
 
-            local rowHover = mx and my and pointInRect(mx, my, { x = rowRectX, y = rowRectY, w = rowRectW, h = rowRectH })
+            local rowHover = mx and my and UIUtils.pointInRect(mx, my, { x = rowRectX, y = rowRectY, w = rowRectW, h = rowRectH }, { inclusive = false })
             Theme.setColor(rowHover and Theme.withAlpha(Theme.colors.hover, 0.85) or Theme.withAlpha(Theme.colors.bg3, 0.55))
             love.graphics.rectangle("fill", rowRectX, rowRectY, rowRectW, rowRectH, 6, 6)
 
@@ -692,7 +680,7 @@ function Ship:draw(player, x, y, w, h)
                     hotbarRect.w = math.max(56, hotbarRect.w - overflow)
                     removeRect.x = hotbarRect.x + hotbarRect.w + 8
                 end
-                local hotbarHover = pointInRect(mx, my, hotbarRect)
+                local hotbarHover = UIUtils.pointInRect(mx, my, hotbarRect, { inclusive = false })
 
                 hotbarButton.rect = hotbarRect
                 hotbarButton.hover = hotbarHover
@@ -730,7 +718,7 @@ function Ship:draw(player, x, y, w, h)
                 if oldFont then love.graphics.setFont(oldFont) end
 
                 if slotData and slotData.module then
-                    local removeHover = pointInRect(mx, my, removeRect)
+                    local removeHover = UIUtils.pointInRect(mx, my, removeRect, { inclusive = false })
 
                     self.removeButtons[i].rect = removeRect
                     self.removeButtons[i].hover = removeHover
@@ -811,7 +799,7 @@ function Ship:mousepressed(x, y, button, player)
         content = instance.activeContentBounds
     end
 
-    local insideContent = content and pointInRectSimple(x, y, content)
+    local insideContent = content and UIUtils.pointInRect(x, y, content)
 
     -- Prioritize dropdown interaction when inside content area
     if insideContent and instance.slotDropdowns then
@@ -841,7 +829,7 @@ function Ship:mousepressed(x, y, button, player)
     if button == 1 and instance.hotbarButtons then
         for index, hbButton in ipairs(instance.hotbarButtons) do
             local rect = hbButton and hbButton.rect
-            if hbButton and hbButton.enabled and rect and pointInRect(x, y, rect) then
+            if hbButton and hbButton.enabled and rect and UIUtils.pointInRect(x, y, rect, { inclusive = false }) then
                 local playerModule = player.components and player.components.equipment and player.components.equipment.grid and player.components.equipment.grid[index]
                 if playerModule and playerModule.module then -- Handle any module type
                     -- Cycle to next available hotbar slot, skipping occupied ones
@@ -918,7 +906,7 @@ function Ship:mousepressed(x, y, button, player)
     if button == 1 and instance.removeButtons then
         for index, removeButton in ipairs(instance.removeButtons) do
             local rect = removeButton and removeButton.rect
-            if rect and pointInRect(x, y, rect) then
+            if rect and UIUtils.pointInRect(x, y, rect, { inclusive = false }) then
                 local unequipped = player.unequipModule and player:unequipModule(index)
                 if unequipped then
                     instance:updateDropdowns(player)
@@ -1011,13 +999,13 @@ function Ship:wheelmoved(x, y, dx, dy)
     local handled = false
     local scrollDelta = dy * 28
 
-    if instance.statsViewRect and pointInRectSimple(x, y, instance.statsViewRect) then
+    if instance.statsViewRect and UIUtils.pointInRect(x, y, instance.statsViewRect) then
         local minScroll = instance.statsViewRect.minScroll or 0
         instance.statsScroll = clamp((instance.statsScroll or 0) + scrollDelta, minScroll, 0)
         handled = true
     end
 
-    if instance.slotViewRect and pointInRectSimple(x, y, instance.slotViewRect) then
+    if instance.slotViewRect and UIUtils.pointInRect(x, y, instance.slotViewRect) then
         local minScroll = instance.slotViewRect.minScroll or 0
         instance.slotScroll = clamp((instance.slotScroll or 0) + scrollDelta, minScroll, 0)
         handled = true

--- a/src/ui/skills.lua
+++ b/src/ui/skills.lua
@@ -9,14 +9,6 @@ local Viewport = require("src.core.viewport")
 local AuroraTitle = require("src.shaders.aurora_title")
 local Window = require("src.ui.common.window")
 
-local function pointInRect(px, py, r)
-    -- Handle nil values gracefully
-    if px == nil or py == nil or r == nil or r.x == nil or r.y == nil or r.w == nil or r.h == nil then
-        return false
-    end
-    return px >= r.x and py >= r.y and px <= r.x + r.w and py <= r.y + r.h
-end
-
 local function drawSkillBar(x, y, w, h, progress, skillName, level, xp, xpToNext)
     -- Enhanced background
     Theme.drawGradientGlowRect(x, y, w, h, 4,

--- a/src/ui/version_log.lua
+++ b/src/ui/version_log.lua
@@ -3,6 +3,7 @@ local Viewport = require("src.core.viewport")
 local Strings = require("src.core.strings")
 local ScrollArea = require("src.ui.common.scroll_area")
 local Json = require("src.libs.json")
+local UIUtils = require("src.ui.common.utils")
 
 local VersionLog = {
     visible = false,
@@ -172,10 +173,6 @@ local function clampScroll()
         return
     end
     VersionLog.scrollY = math.max(0, math.min(maxScroll, VersionLog.scrollY))
-end
-
-local function pointInRect(px, py, rx, ry, rw, rh)
-    return px >= rx and px <= rx + rw and py >= ry and py <= ry + rh
 end
 
 local function getRepoDir()
@@ -611,11 +608,11 @@ function VersionLog.mousepressed(mx, my, button)
 
     if button == 1 and VersionLog.scrollGeom and VersionLog.scrollGeom.thumb then
         local thumb = VersionLog.scrollGeom.thumb
-        if pointInRect(mx, my, thumb.x, thumb.y, thumb.w, thumb.h) then
+        if UIUtils.pointInRect(mx, my, thumb) then
             VersionLog.scrollState.dragging = true
             VersionLog.scrollState.dragOffset = my - thumb.y
             return true
-        elseif pointInRect(mx, my, VersionLog.scrollGeom.track.x, VersionLog.scrollGeom.track.y, VersionLog.scrollGeom.track.w, VersionLog.scrollGeom.track.h) then
+        elseif UIUtils.pointInRect(mx, my, VersionLog.scrollGeom.track) then
             local track = VersionLog.scrollGeom.track
             local thumbHeight = VersionLog.scrollGeom.thumb.h
             local clampedY = math.max(track.y, math.min(track.y + track.h - thumbHeight, my - thumbHeight * 0.5))
@@ -688,7 +685,7 @@ function VersionLog.wheelmoved(x, y, dx, dy)
         return false
     end
     if VersionLog.bounds then
-        if not pointInRect(x, y, VersionLog.bounds.x, VersionLog.bounds.y, VersionLog.bounds.w, VersionLog.bounds.h) then
+        if not UIUtils.pointInRect(x, y, VersionLog.bounds) then
             return false
         end
     end


### PR DESCRIPTION
## Summary
- route UI hit detection through `UIUtils.pointInRect` with optional inclusive bounds handling
- remove duplicated `pointInRect` helpers from bounty, ship, save slots, and related panels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dac71425048322a9fc01269368bce1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes all UI hit-testing through a new, flexible UIUtils.pointInRect API and removes duplicated helpers across panels.
> 
> - **Core UI Utils**:
>   - Enhance `UIUtils.pointInRect` to accept either a `rect` or `(x, y, w, h)` plus optional `options`/`inclusive` for inclusive/exclusive edges; adds nil-safety.
> - **Panels updated to use centralized hit-testing**:
>   - `src/ui/bounty.lua`: Replace local checks for scrollbar/thumb and claim button with `UIUtils.pointInRect`.
>   - `src/ui/save_slots.lua`: Use `UIUtils.pointInRect` for save/load buttons, slot body/delete, and autosave load; remove local helper.
>   - `src/ui/ship.lua`: Use `UIUtils.pointInRect` for row/controls hovers, hotbar and remove buttons, content/scroll areas (some with `{ inclusive = false }`); remove local helpers.
>   - `src/ui/version_log.lua`: Use `UIUtils.pointInRect` for scrollbar thumb/track and bounds checks; remove local helper.
>   - `src/ui/hud/hotbar.lua`: Remove unused local `pointInRect` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 723fd9353a56e56646c6860137d280246800cdde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->