### PR TITLE
Share Window Mode Helper

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,7 @@ local Sound = require("src.core.sound")
 local DebugPanel = require("src.ui.debug_panel")
 local Constants = require("src.core.constants")
 local LoadingScreen = require("src.ui.loading_screen")
+local WindowMode = require("src.core.window_mode")
 
 --[[
     The main module is responsible for orchestrating high-level state changes
@@ -70,33 +71,12 @@ function updateFPSLimit()
   minFrameTime = (graphicsSettings.max_fps and graphicsSettings.max_fps > 0) and (1 / graphicsSettings.max_fps) or 0
 end
 
-local function applyWindowMode(graphicsSettings)
-    local ok, err = pcall(function()
-        love.window.setMode(
-            graphicsSettings.resolution.width,
-            graphicsSettings.resolution.height,
-            {
-                fullscreen = graphicsSettings.fullscreen,
-                fullscreentype = graphicsSettings.fullscreen_type,
-                borderless = graphicsSettings.borderless,
-                vsync = graphicsSettings.vsync,
-                resizable = true,
-                minwidth = Constants.RESOLUTION.MIN_WINDOW_WIDTH_1024PX,
-                minheight = Constants.RESOLUTION.MIN_WINDOW_HEIGHT_1024PX,
-            }
-        )
-    end)
-
-    if not ok then
-        local Log = require("src.core.log")
-        Log.warn("Failed to apply window mode: " .. tostring(err))
-    end
-end
-
 function love.applyGraphicsSettings()
     local graphicsSettings = Settings.getGraphicsSettings()
-    applyWindowMode(graphicsSettings)
-    Viewport.init(graphicsSettings.resolution.width, graphicsSettings.resolution.height)
+    local success = WindowMode.apply(graphicsSettings)
+    if success then
+        Viewport.init(graphicsSettings.resolution.width, graphicsSettings.resolution.height)
+    end
     updateFPSLimit()
 end
 

--- a/src/core/window_mode.lua
+++ b/src/core/window_mode.lua
@@ -1,0 +1,81 @@
+local WindowMode = {}
+
+local Log = require("src.core.log")
+local Constants = require("src.core.constants")
+
+local function computeMinimumDimensions(width, height)
+    local minWidth
+    if width <= Constants.RESOLUTION.MIN_WINDOW_WIDTH_800PX then
+        minWidth = math.max(Constants.RESOLUTION.MIN_WINDOW_WIDTH_800PX, width)
+    else
+        minWidth = Constants.RESOLUTION.MIN_WINDOW_WIDTH_1024PX
+    end
+
+    local minHeight
+    if height <= Constants.RESOLUTION.MIN_WINDOW_HEIGHT_800PX then
+        minHeight = math.max(Constants.RESOLUTION.MIN_WINDOW_HEIGHT_800PX, height)
+    else
+        minHeight = Constants.RESOLUTION.MIN_WINDOW_HEIGHT_1024PX
+    end
+
+    return minWidth, minHeight
+end
+
+function WindowMode.apply(graphicsSettings)
+    if not love or not love.window or not love.window.setMode then
+        if Log and Log.warn then
+            Log.warn("WindowMode.apply - love.window.setMode is unavailable")
+        end
+        return false, "love.window.setMode unavailable"
+    end
+
+    if not graphicsSettings or not graphicsSettings.resolution then
+        if Log and Log.warn then
+            Log.warn("WindowMode.apply - Missing graphics settings or resolution")
+        end
+        return false, "invalid graphics settings"
+    end
+
+    local width = graphicsSettings.resolution.width
+    local height = graphicsSettings.resolution.height
+
+    local minWidth, minHeight = computeMinimumDimensions(width, height)
+
+    Log.debug("WindowMode.apply - Using minimum window size: " .. minWidth .. "x" .. minHeight)
+
+    local windowSettings = {
+        fullscreen = graphicsSettings.fullscreen,
+        fullscreentype = graphicsSettings.fullscreen_type or "desktop",
+        borderless = graphicsSettings.borderless or false,
+        vsync = graphicsSettings.vsync,
+        resizable = true,
+        minwidth = minWidth,
+        minheight = minHeight,
+    }
+
+    if windowSettings.borderless then
+        windowSettings.fullscreen = false
+        windowSettings.borderless = true
+    end
+
+    Log.debug("WindowMode.apply - Applying window mode:")
+    Log.debug("  Resolution: " .. width .. "x" .. height)
+    Log.debug("  Fullscreen: " .. tostring(windowSettings.fullscreen))
+    Log.debug("  Fullscreen type: " .. (windowSettings.fullscreentype or "nil"))
+    Log.debug("  Borderless: " .. tostring(windowSettings.borderless))
+    Log.debug("  VSync: " .. tostring(windowSettings.vsync))
+
+    local ok, err = pcall(love.window.setMode, width, height, windowSettings)
+
+    if not ok then
+        if Log and Log.warn then
+            Log.warn("WindowMode.apply - Failed to apply window mode: " .. tostring(err))
+        end
+        return false, err
+    end
+
+    Log.debug("WindowMode.apply - Window mode applied successfully")
+    return true
+end
+
+return WindowMode


### PR DESCRIPTION
## Summary
- extract shared window mode helper so main and settings configure Love2D consistently
- update `love.applyGraphicsSettings` and settings module to delegate to the helper while keeping viewport, icon, and FPS tasks localized

## Testing
- not run (Love2D runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dac7226218832281c78bad0f486a21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared `WindowMode.apply` and update `main.lua` and `src/core/settings.lua` to delegate window mode changes with safer error handling; keep viewport init, icon rebuild, resize, and FPS logic intact.
> 
> - **Core**:
>   - Add `src/core/window_mode.lua` with `WindowMode.apply` to compute min dimensions, log, and safely call `love.window.setMode`.
> - **Graphics settings integration**:
>   - `main.lua`: replace local window-mode logic with `WindowMode.apply`; only init `Viewport` on success; keep FPS limit update.
>   - `src/core/settings.lua`: delegate window mode changes to `WindowMode.apply`; log and early-return on failure; retain icon cache clear/rebuild and resize event trigger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab943b29d2d7cbd72c6b962ca51ec2081fbbbda2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->