### PR TITLE
Add rollback when window mode application fails

### DIFF
--- a/src/core/settings.lua
+++ b/src/core/settings.lua
@@ -129,7 +129,7 @@ function Settings.getAvailableResolutions()
 end
 
 function Settings.applyGraphicsSettings(newSettings)
-    local oldSettings = settings.graphics
+    local oldSettings = Util.deepCopy(settings.graphics)
     settings.graphics = newSettings
 
     -- Only change window mode if resolution or fullscreen settings changed
@@ -145,6 +145,10 @@ function Settings.applyGraphicsSettings(newSettings)
         if not success then
             if Log and Log.warn then
                 Log.warn("Settings.applyGraphicsSettings - Failed to apply window mode: " .. tostring(err))
+            end
+            settings.graphics = oldSettings
+            if Log and Log.warn then
+                Log.warn("Settings.applyGraphicsSettings - Rolling back to previous graphics settings")
             end
             return
         end


### PR DESCRIPTION
## Summary
- copy the previous graphics settings before applying new values
- restore the old settings and log a warning if applying the window mode fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dad5b2653483228415cdac5284f7a1