### PR TITLE
Revamp Station Contract Generation

### DIFF
--- a/src/systems/quest_system.lua
+++ b/src/systems/quest_system.lua
@@ -167,6 +167,20 @@ local function handleObjectiveEvent(player, eventName, data)
                 end
             end
         end
+    elseif eventName == Events.GAME_EVENTS.WRECKAGE_SALVAGED then
+        if not data or (data.player and data.player ~= player) then return end
+        local resourceId = data.resourceId or "scraps"
+        local amount = data.amount or 1
+        if amount <= 0 then return end
+
+        for _, quest in ipairs(questLog.active) do
+            local objective = quest.objective
+            if objective and objective.type == "salvage" then
+                if targetMatches(objective.target, { resourceId }) then
+                    QuestSystem.addProgress(player, quest.id, amount)
+                end
+            end
+        end
     end
 end
 
@@ -204,6 +218,7 @@ function QuestSystem.init(player)
 
         subscribe(Events.GAME_EVENTS.ENTITY_DESTROYED)
         subscribe(Events.GAME_EVENTS.ASTEROID_MINED)
+        subscribe(Events.GAME_EVENTS.WRECKAGE_SALVAGED)
     end
 end
 

--- a/src/systems/salvage.lua
+++ b/src/systems/salvage.lua
@@ -1,6 +1,7 @@
 local SalvageSystem = {}
 local Skills = require("src.core.skills")
 local Notifications = require("src.ui.notifications")
+local Events = require("src.core.events")
 
 function SalvageSystem.update(dt, world, player)
   for _, entity in ipairs(world:get_entities_with_components("wreckage", "timed_life")) do
@@ -23,6 +24,14 @@ function SalvageSystem.update(dt, world, player)
                     math.random(-80, 80)
                 )
                 table.insert(world.entities, pickup)
+
+                Events.emit(Events.GAME_EVENTS.WRECKAGE_SALVAGED, {
+                    player = player,
+                    amount = 1,
+                    resourceId = wreckage.resourceType or "scraps",
+                    wreckage = entity,
+                    wreckageId = entity.id
+                })
 
                 local xpBase = 10 -- base XP per salvaged resource
                 local salvagingLevel = Skills.getLevel("salvaging")


### PR DESCRIPTION
## Summary
- expand station quest generator to build mining, drone-hunting, and wreckage-salvage contracts that reward only universal XP
- add salvage event tracking so salvage quests advance alongside mining and combat goals
- emit salvage completion events from the salvaging system to feed the quest log

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dad950ffdc83228d61b2cdb9717c2d