### PR TITLE
Introduce Varied Asteroid Sizes and Chunk Rendering

### DIFF
--- a/content/world_objects/asteroid_large.lua
+++ b/content/world_objects/asteroid_large.lua
@@ -1,0 +1,50 @@
+-- Data definition for a large asteroid with prominent mineral protrusions.
+return {
+    id = "asteroid_large",
+    name = "Large Asteroid",
+    class = "WorldObject",
+
+    renderable = {
+        type = "asteroid",
+        props = {
+            size = "large",
+            chunkOptions = {
+                chunkCount = {3, 5},
+                chunkSize = {0.24, 0.36},
+                chunkOffset = {1.1, 1.4},
+                chunkSquash = {0.7, 1.0},
+                chunkPalette = {
+                    {0.55, 0.47, 0.52, 1.0},
+                    {0.61, 0.5, 0.44, 1.0},
+                    {0.5, 0.52, 0.63, 1.0},
+                },
+                chunkOutline = {0.17, 0.17, 0.19, 1.0},
+            },
+        }
+    },
+
+    collidable = {
+        radius = 52,
+    },
+
+    mineable = {
+        resourceType = "stones",
+        resources = 140,
+        durability = 30.0,
+    },
+
+    visuals = {
+        colors = {
+            small = {0.42, 0.42, 0.46, 1.0},
+            medium = {0.38, 0.38, 0.42, 1.0},
+            large = {0.32, 0.32, 0.36, 1.0},
+            outline = {0.18, 0.18, 0.2, 1.0},
+            chunkPalette = {
+                {0.63, 0.52, 0.48, 1.0},
+                {0.52, 0.55, 0.67, 1.0},
+                {0.57, 0.49, 0.58, 1.0},
+            },
+            chunkOutline = {0.17, 0.17, 0.19, 1.0},
+        }
+    }
+}

--- a/content/world_objects/asteroid_medium.lua
+++ b/content/world_objects/asteroid_medium.lua
@@ -8,25 +8,43 @@ return {
         type = "asteroid",
         props = {
             size = "medium",
-            -- The actual vertices will be generated procedurally
+            chunkOptions = {
+                chunkCount = {2, 4},
+                chunkSize = {0.2, 0.32},
+                chunkOffset = {1.05, 1.35},
+                chunkSquash = {0.6, 0.95},
+                chunkPalette = {
+                    {0.58, 0.51, 0.46, 1.0},
+                    {0.52, 0.47, 0.55, 1.0},
+                    {0.63, 0.56, 0.48, 1.0},
+                },
+                chunkOutline = {0.18, 0.18, 0.2, 1.0},
+            },
         }
     },
 
     collidable = {
-        radius = 35, -- Average radius
+        radius = 36,
     },
 
     mineable = {
-        resourceType = "stones", -- drop stone items
-        durability = 20.0, -- mining damage needed to destroy
+        resourceType = "stones",
+        resources = 90,
+        durability = 22.0,
     },
 
     visuals = {
         colors = {
+            small = {0.43, 0.43, 0.48, 1.0},
             medium = {0.4, 0.4, 0.45, 1.0},
-            rich = {0.8, 0.7, 0.3, 1.0}, -- Gold-ish
-            dense = {0.6, 0.6, 0.7, 1.0}, -- Palladium-ish
-            outline = {0.2, 0.2, 0.2, 1.0}
+            large = {0.34, 0.34, 0.39, 1.0},
+            outline = {0.2, 0.2, 0.22, 1.0},
+            chunkPalette = {
+                {0.66, 0.57, 0.45, 1.0},
+                {0.55, 0.52, 0.62, 1.0},
+                {0.62, 0.5, 0.41, 1.0},
+            },
+            chunkOutline = {0.18, 0.18, 0.2, 1.0},
         }
     }
 }

--- a/content/world_objects/asteroid_small.lua
+++ b/content/world_objects/asteroid_small.lua
@@ -1,0 +1,48 @@
+-- Data definition for a small, jagged asteroid with visible mineral chunks.
+return {
+    id = "asteroid_small",
+    name = "Small Asteroid",
+    class = "WorldObject",
+
+    renderable = {
+        type = "asteroid",
+        props = {
+            size = "small",
+            chunkOptions = {
+                chunkCount = {1, 2},
+                chunkSize = {0.16, 0.24},
+                chunkOffset = {1.0, 1.25},
+                chunkSquash = {0.6, 0.9},
+                chunkPalette = {
+                    {0.62, 0.55, 0.48, 1.0},
+                    {0.53, 0.5, 0.6, 1.0},
+                },
+                chunkOutline = {0.2, 0.2, 0.23, 1.0},
+            },
+        }
+    },
+
+    collidable = {
+        radius = 24,
+    },
+
+    mineable = {
+        resourceType = "stones",
+        resources = 45,
+        durability = 12.0,
+    },
+
+    visuals = {
+        colors = {
+            small = {0.46, 0.46, 0.5, 1.0},
+            medium = {0.42, 0.42, 0.47, 1.0},
+            large = {0.36, 0.36, 0.4, 1.0},
+            outline = {0.22, 0.22, 0.24, 1.0},
+            chunkPalette = {
+                {0.68, 0.6, 0.5, 1.0},
+                {0.57, 0.53, 0.64, 1.0},
+            },
+            chunkOutline = {0.2, 0.2, 0.23, 1.0},
+        }
+    }
+}

--- a/src/content/normalizer.lua
+++ b/src/content/normalizer.lua
@@ -95,6 +95,10 @@ function Normalizer.normalizeWorldObject(def)
       resources = m.resources or m.amount or 0,
       resourceType = m.resourceType or m.id or "stone",
       mineCycleTime = m.mineCycleTime or 1.0,
+      durability = m.durability,
+      maxDurability = m.maxDurability,
+      extractionCycle = m.extractionCycle,
+      activeCyclesPerResource = m.activeCyclesPerResource,
     }
   end
 

--- a/src/systems/render/entity_renderers.lua
+++ b/src/systems/render/entity_renderers.lua
@@ -296,16 +296,43 @@ function EntityRenderers.asteroid(entity, player)
         
         -- No hover-based color changes; rely on active beam effects only
         
-        RenderUtils.setColor(fillColor)
-        
         -- Unpack the nested vertex table for Love2D's polygon function
         local flatVertices = {}
         for _, vertex in ipairs(vertices) do
             table.insert(flatVertices, vertex[1])
             table.insert(flatVertices, vertex[2])
         end
-        
+
+        RenderUtils.setColor(fillColor)
         love.graphics.polygon("fill", flatVertices)
+
+        -- Draw protruding chunks sitting on top of the base rock
+        local chunks = props.chunks or {}
+        local chunkOutlineColor = colors.chunkOutline or outlineColor
+        local chunkPalette = colors.chunkPalette or colors.chunks
+        for _, chunk in ipairs(chunks) do
+            local chunkColor = chunk.color or (chunkPalette and chunkPalette[1]) or fillColor
+            RenderUtils.setColor(chunkColor)
+            if chunk.shape == "ellipse" then
+                love.graphics.ellipse("fill", chunk.x or 0, chunk.y or 0, chunk.rx or 4, chunk.ry or chunk.rx or 4)
+                RenderUtils.setColor(chunk.outlineColor or chunkOutlineColor)
+                love.graphics.ellipse("line", chunk.x or 0, chunk.y or 0, chunk.rx or 4, chunk.ry or chunk.rx or 4)
+            elseif chunk.shape == "circle" then
+                love.graphics.circle("fill", chunk.x or 0, chunk.y or 0, chunk.r or 4)
+                RenderUtils.setColor(chunk.outlineColor or chunkOutlineColor)
+                love.graphics.circle("line", chunk.x or 0, chunk.y or 0, chunk.r or 4)
+            elseif chunk.shape == "polygon" and chunk.vertices then
+                local flat = {}
+                for _, v in ipairs(chunk.vertices) do
+                    table.insert(flat, v[1])
+                    table.insert(flat, v[2])
+                end
+                love.graphics.polygon("fill", flat)
+                RenderUtils.setColor(chunk.outlineColor or chunkOutlineColor)
+                love.graphics.polygon("line", flat)
+            end
+        end
+
         RenderUtils.setColor(outlineColor)
         love.graphics.polygon("line", flatVertices)
         

--- a/src/systems/spawning.lua
+++ b/src/systems/spawning.lua
@@ -22,6 +22,29 @@ local maxEnemies = getSpawnValue("MAX_ENEMIES") or 36 -- Significantly increased
 local maxBosses = 3   -- Hard cap on boss drones
 local maxAsteroids = 15
 
+local asteroidVariants = {
+  { id = "asteroid_small", weight = 3 },
+  { id = "asteroid_medium", weight = 4 },
+  { id = "asteroid_large", weight = 2 },
+}
+
+local function pickAsteroidId()
+  local totalWeight = 0
+  for _, variant in ipairs(asteroidVariants) do
+    totalWeight = totalWeight + (variant.weight or 1)
+  end
+
+  local roll = math.random() * totalWeight
+  for _, variant in ipairs(asteroidVariants) do
+    roll = roll - (variant.weight or 1)
+    if roll <= 0 then
+      return variant.id
+    end
+  end
+
+  return asteroidVariants[1] and asteroidVariants[1].id or "asteroid_medium"
+end
+
 -- Check if a position is within any custom no-spawn zones
 local function isPositionInNoSpawnZone(x, y)
   local zones = spawnOverrides.NO_SPAWN_ZONES
@@ -249,9 +272,8 @@ local function spawnAsteroid(hub, world)
     end
   until (ok_stations and ok_hub and ok_others) or attempts > 200
   
-  -- For now, we only have one type of asteroid defined.
-  -- This could be expanded to randomly select from different asteroid data files.
-  local asteroid = EntityFactory.create("world_object", "asteroid_medium", x, y)
+  local asteroidId = pickAsteroidId()
+  local asteroid = EntityFactory.create("world_object", asteroidId, x, y)
   if asteroid then
       world:addEntity(asteroid)
   end

--- a/src/templates/world_object.lua
+++ b/src/templates/world_object.lua
@@ -52,8 +52,12 @@ function WorldObject.new(x, y, angle, friendly, config)
     -- Special procedural generation for asteroid vertices
     if self.components.renderable and self.components.renderable.type == "asteroid" then
         local r = self.components.collidable and self.components.collidable.radius or 30
-        local vertsNested = Util.generateAsteroidVertices(r)
+        local geometry = Util.generateAsteroidGeometry(r, self.components.renderable.props.chunkOptions)
+        local vertsNested = geometry.vertices
         self.components.renderable.props.vertices = vertsNested
+        if geometry.chunks then
+            self.components.renderable.props.chunks = geometry.chunks
+        end
         -- Build a flat vertex list for polygon collisions
         local flat = {}
         for _, v in ipairs(vertsNested or {}) do


### PR DESCRIPTION
## Summary
- add small, medium, and large asteroid content definitions with varied colors and chunk options
- generate asteroid geometry with detachable chunk data and render the protruding minerals
- randomize asteroid spawning and preserve mineable durability during normalization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dad9b57ae88322a6b637a292e8c6b2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds small/large asteroid types, procedural chunk/chunked geometry and rendering, extended mineable fields, and weighted random asteroid spawning.
> 
> - **Content**:
>   - **Asteroids**: Add `content/world_objects/asteroid_small.lua` and `asteroid_large.lua`; enhance `asteroid_medium.lua` with `chunkOptions`, updated colors, radius, resources, and durability.
> - **Rendering**:
>   - **Asteroid Chunks**: Render protruding mineral chunks (`ellipse/circle/polygon`) atop base asteroid in `src/systems/render/entity_renderers.lua`.
> - **Geometry/Util**:
>   - Introduce `util.generateAsteroidGeometry(radius, opts)` producing `vertices` + `chunks`; keep `generateAsteroidVertices` delegating to it.
> - **World Object Template**:
>   - Use new geometry on asteroid init; attach `props.vertices` and `props.chunks`; upgrade collidable to polygon.
> - **Spawning**:
>   - Add weighted selection of asteroid variants (small/medium/large) instead of single type.
> - **Normalization**:
>   - Preserve additional mineable fields: `durability`, `maxDurability`, `extractionCycle`, `activeCyclesPerResource`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b45184219f457e740a9de2cfef4a9f9c9e50e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->