### PR TITLE
Align Enemy Config With Ship Definitions

### DIFF
--- a/content/ships/basic_drone.lua
+++ b/content/ships/basic_drone.lua
@@ -122,7 +122,7 @@ return {
                     hull = { spark = {1.0, 0.2, 0.2, 0.5}, ring = {1.0, 0.1, 0.1, 0.4} },
                 },
                 optimal = 600, falloff = 300, -- Shorter range than player lasers
-                damage_range = { min = 6, max = 10 },
+                damage_range = { min = 2, max = 4 },
                 cycle = 1.5, capCost = 0, -- No energy cost for basic enemies
                 spread = { minDeg = 0.1, maxDeg = 0.3, decay = 600 },
                 maxRange = 800, -- Shorter range
@@ -142,6 +142,17 @@ return {
 
     bounty = 8,
     xpReward = 10,
+
+    enemy = {
+        sizeMultiplier = 1.5,
+        collidableRadiusMultiplier = 1.5,
+        physicsRadiusMultiplier = 1.5,
+        energyRegen = 20,
+        turretBehavior = {
+            fireMode = "automatic",
+            autoFire = true,
+        },
+    },
 
     loot = {
         drops = {

--- a/content/ships/boss_drone.lua
+++ b/content/ships/boss_drone.lua
@@ -222,6 +222,18 @@ return {
   bounty = 60,
   xpReward = 100,
 
+  enemy = {
+    isBoss = true,
+    sizeMultiplier = 5.0,
+    collidableRadiusMultiplier = 5.0,
+    physicsRadiusMultiplier = 5.0,
+    energyRegen = 40,
+    turretBehavior = {
+      fireMode = "automatic",
+      autoFire = true,
+    },
+  },
+
   loot = {
     drops = {
       { id = "ore_tritanium", min = 3, max = 6, chance = 0.9 },

--- a/src/content/normalizer.lua
+++ b/src/content/normalizer.lua
@@ -9,6 +9,15 @@ local function copy(t)
   return o
 end
 
+local function deepCopy(value)
+  if type(value) ~= "table" then return value end
+  local result = {}
+  for k, v in pairs(value) do
+    result[k] = deepCopy(v)
+  end
+  return result
+end
+
 -- Ensure visuals table exists with defaults
 local function normVisuals(v)
   v = v or {}
@@ -23,10 +32,10 @@ function Normalizer.normalizeShip(def)
   out.name = def.name or def.id or "Unknown Ship"
   out.class = def.class or "Ship"
   out.description = def.description or def.desc or ""
-  out.visuals = normVisuals(copy(def.visuals))
+  out.visuals = normVisuals(deepCopy(def.visuals))
   -- AI configuration passthrough
   if def.ai then
-    out.ai = copy(def.ai)
+    out.ai = deepCopy(def.ai)
   end
 
   -- Hull
@@ -44,17 +53,17 @@ function Normalizer.normalizeShip(def)
   }
   -- Signature, cargo
   out.sig = def.sig or (def.collidable and def.collidable.signature) or 100
-  out.cargo = def.cargo and copy(def.cargo) or { capacity = 100 }
+  out.cargo = def.cargo and deepCopy(def.cargo) or { capacity = 100 }
   out.equipmentSlots = def.equipmentSlots or def.equipment_slots or def.gridSlots
   if type(def.equipmentLayout) == 'table' then
     out.equipmentLayout = {}
     for i, slotDef in ipairs(def.equipmentLayout) do
-      out.equipmentLayout[i] = copy(slotDef)
+      out.equipmentLayout[i] = deepCopy(slotDef)
     end
   end
   -- Hardpoints: accept direct hardpoints or simple turrets list
   if type(def.hardpoints) == 'table' then
-    out.hardpoints = def.hardpoints
+    out.hardpoints = deepCopy(def.hardpoints)
   elseif type(def.turrets) == 'table' then
     out.hardpoints = {}
     for i, tid in ipairs(def.turrets) do out.hardpoints[i] = { turret = tid } end
@@ -63,8 +72,21 @@ function Normalizer.normalizeShip(def)
   end
   -- Loot settings passthrough
   if def.loot and type(def.loot.drops) == 'table' then
-    out.loot = { drops = def.loot.drops }
+    out.loot = { drops = deepCopy(def.loot.drops) }
   end
+  if def.enemy then
+    out.enemy = deepCopy(def.enemy)
+  end
+  if def.variants then
+    out.variants = deepCopy(def.variants)
+  end
+  if def.bounty ~= nil then out.bounty = def.bounty end
+  if def.xpReward ~= nil then out.xpReward = def.xpReward end
+  if def.energyRegen ~= nil or def.energy_regen ~= nil then
+    out.energyRegen = def.energyRegen or def.energy_regen
+  end
+  if def.isEnemy ~= nil then out.isEnemy = def.isEnemy end
+  if def.isBoss ~= nil then out.isBoss = def.isBoss end
   return out
 end
 

--- a/src/templates/entity_factory.lua
+++ b/src/templates/entity_factory.lua
@@ -108,88 +108,134 @@ end
 -- Create an enemy ship
 function EntityFactory.createEnemy(shipId, x, y)
     local shipConfig = Content.getShip(shipId)
-    local config = {
-        isEnemy = true,
-        bounty = (shipConfig and shipConfig.bounty) or 25,
-        xpReward = (shipConfig and shipConfig.xpReward) or 50,
-        energyRegen = 35, -- Faster regen than player (20) for aggressive firing,
-        shipId = shipId, -- Store ship ID for quest tracking
-    }
+    local enemySettings = {}
+    if shipConfig and shipConfig.enemy then
+        enemySettings = Util.deepCopy(shipConfig.enemy)
+    end
+
+    local config = {}
+    if type(enemySettings.entity) == "table" then
+        for k, v in pairs(enemySettings.entity) do
+            config[k] = Util.deepCopy(v)
+        end
+    end
+
+    config.isEnemy = true
+    config.shipId = shipId -- Store ship ID for quest tracking
+
+    if config.bounty == nil then
+        config.bounty = enemySettings.bounty or (shipConfig and shipConfig.bounty) or 25
+    end
+    if config.xpReward == nil then
+        config.xpReward = enemySettings.xpReward or (shipConfig and shipConfig.xpReward) or 50
+    end
+    if config.energyRegen == nil then
+        config.energyRegen = enemySettings.energyRegen or (shipConfig and shipConfig.energyRegen) or 35
+    end
+
     local enemy = EntityFactory.create("ship", shipId, x, y, config)
     if enemy and enemy.components then
-        -- Ensure enemy ships spawn with their configured turrets equipped
-        local hardpoints = shipConfig and shipConfig.hardpoints
-        local equipment = enemy.components.equipment
-        if hardpoints and equipment and equipment.grid then
-            local grid = equipment.grid
-            local function getSlot(index)
-                if not grid[index] then
-                    grid[index] = { slot = index, id = nil, module = nil, enabled = false, type = nil }
-                end
-                return grid[index]
-            end
+        enemy.enemyConfig = Util.deepCopy(enemySettings)
 
-            local nextSlot = 1
-            for _, hardpoint in ipairs(hardpoints) do
-                local turretId = hardpoint.turret or hardpoint.id
-                local turretDef = nil
-                
-                -- Check if turret is embedded (table) or external (string ID)
-                if type(turretId) == "table" then
-                    -- Embedded turret definition
-                    turretDef = turretId
-                    turretId = turretDef.id or "embedded_turret_" .. nextSlot
-                else
-                    -- External turret definition
-                    turretDef = Content.getTurret(turretId)
-                end
-                
-                if turretDef then
-                    local turretParams = Util.deepCopy(turretDef)
-                    turretParams.fireMode = turretParams.fireMode or "automatic"
-                    local turretInstance = TurretCore.new(enemy, turretParams)
-                    turretInstance.fireMode = "automatic"
-                    turretInstance.autoFire = true
-
-                    local slotIndex = hardpoint.slot or nextSlot
-                    local slot = getSlot(slotIndex)
-                    slot.id = turretId
-                    slot.module = turretInstance
-                    slot.enabled = true
-                    slot.type = "turret"
-
-                    nextSlot = math.max(nextSlot, slotIndex + 1)
-                else
-                    Log.warn("EntityFactory - Missing turret definition for", tostring(turretId))
-                end
+        if type(enemySettings.entity) == "table" then
+            for k, v in pairs(enemySettings.entity) do
+                enemy[k] = Util.deepCopy(v)
             end
         end
 
-        -- Mark bosses for special handling
-        if shipId == 'boss_drone' then
+        if enemySettings.isBoss ~= nil then
+            enemy.isBoss = enemySettings.isBoss
+        elseif shipConfig and shipConfig.isBoss ~= nil then
+            enemy.isBoss = shipConfig.isBoss
+        elseif shipId == 'boss_drone' then
             enemy.isBoss = true
         end
-        -- Make enemy drones a bit larger than base (boss drones scale up further)
+
+        local sizeMultiplier = enemySettings.sizeMultiplier or 1.0
+        local collidableMultiplier = enemySettings.collidableRadiusMultiplier or sizeMultiplier
+        local physicsMultiplier = enemySettings.physicsRadiusMultiplier or sizeMultiplier
+
         local rend = enemy.components.renderable
-        if rend and rend.props and rend.props.visuals then
+        if rend and rend.props and rend.props.visuals and sizeMultiplier ~= 1.0 then
             local visuals = rend.props.visuals
-            local baseSize = visuals.size or 1.0
-            local sizeMultiplier = shipId == 'boss_drone' and 5.0 or 1.5
-            visuals.size = baseSize * sizeMultiplier
+            visuals.size = (visuals.size or 1.0) * sizeMultiplier
         end
-        if enemy.components.collidable then
+        if enemy.components.collidable and collidableMultiplier ~= 1.0 then
             local baseRadius = enemy.components.collidable.radius or 10
-            local radiusMultiplier = shipId == 'boss_drone' and 5.0 or 1.5
-            enemy.components.collidable.radius = baseRadius * radiusMultiplier
+            enemy.components.collidable.radius = baseRadius * collidableMultiplier
         end
-        if enemy.components.physics and enemy.components.physics.body then
+        if enemy.components.physics and enemy.components.physics.body and physicsMultiplier ~= 1.0 then
             local baseBodyRadius = enemy.components.physics.body.radius or 10
-            local bodyMultiplier = shipId == 'boss_drone' and 5.0 or 1.5
-            enemy.components.physics.body.radius = baseBodyRadius * bodyMultiplier
+            enemy.components.physics.body.radius = baseBodyRadius * physicsMultiplier
         end
-        -- Clear any cached shield radius so it recomputes using new visuals size
+
         enemy.shieldRadius = nil
         enemy._shieldRadiusVisualSize = nil
+
+        local autoEquipTurrets = enemySettings.autoEquipTurrets
+        if autoEquipTurrets == nil then autoEquipTurrets = true end
+
+        if autoEquipTurrets then
+            local hardpoints = shipConfig and shipConfig.hardpoints
+            local equipment = enemy.components.equipment
+            if hardpoints and equipment and equipment.grid then
+                local turretBehavior = enemySettings.turretBehavior or {}
+                local defaultFireMode = turretBehavior.fireMode or "automatic"
+                local defaultAutoFire = turretBehavior.autoFire
+                if defaultAutoFire == nil then
+                    defaultAutoFire = true
+                end
+
+                local grid = equipment.grid
+                local function getSlot(index)
+                    if not grid[index] then
+                        grid[index] = { slot = index, id = nil, module = nil, enabled = false, type = nil }
+                    end
+                    return grid[index]
+                end
+
+                local nextSlot = 1
+                for _, hardpoint in ipairs(hardpoints) do
+                    local turretId = hardpoint.turret or hardpoint.id
+                    local turretDef = nil
+
+                    if type(turretId) == "table" then
+                        turretDef = turretId
+                        turretId = turretDef.id or ("embedded_turret_" .. nextSlot)
+                    else
+                        turretDef = Content.getTurret(turretId)
+                    end
+
+                    if turretDef then
+                        local turretParams = Util.deepCopy(turretDef)
+                        turretParams.fireMode = turretParams.fireMode or defaultFireMode
+                        local turretInstance = TurretCore.new(enemy, turretParams)
+
+                        turretInstance.fireMode = turretInstance.fireMode or defaultFireMode
+                        if turretInstance.fireMode == "automatic" then
+                            if defaultAutoFire ~= nil then
+                                turretInstance.autoFire = defaultAutoFire
+                            elseif turretInstance.autoFire == nil then
+                                turretInstance.autoFire = true
+                            end
+                        elseif defaultAutoFire ~= nil then
+                            turretInstance.autoFire = defaultAutoFire
+                        end
+
+                        local slotIndex = hardpoint.slot or nextSlot
+                        local slot = getSlot(slotIndex)
+                        slot.id = turretId
+                        slot.module = turretInstance
+                        slot.enabled = true
+                        slot.type = "turret"
+
+                        nextSlot = math.max(nextSlot, slotIndex + 1)
+                    else
+                        Log.warn("EntityFactory - Missing turret definition for", tostring(turretId))
+                    end
+                end
+            end
+        end
     end
     return enemy
 end


### PR DESCRIPTION
## Summary
- read enemy-specific settings from ship definitions and apply them during enemy creation
- ensure ship normalization preserves enemy metadata for spawning and scaling
- tune the basic drone's embedded laser damage down to match its content configuration

## Testing
- not run (not available in CI)


------
https://chatgpt.com/codex/tasks/task_b_68db6d454bf88322ba5ebfcd2a20cf39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply per-ship enemy config (scaling, boss flag, turret behavior) during enemy creation, preserve it in normalization, and reduce basic drone laser damage.
> 
> - **Engine**:
>   - `EntityFactory.createEnemy` now reads `ship.enemy`, applies entity overrides, scaling multipliers, boss flag, and stores `enemyConfig`.
>   - Supports `enemy.autoEquipTurrets` (default true) and `enemy.turretBehavior` defaults for `fireMode`/`autoFire` when auto-equipping turrets.
> - **Content**:
>   - `content/ships/basic_drone.lua` and `boss_drone.lua`: add `enemy` blocks with size/collidable/physics multipliers, `energyRegen`, and turret behavior; boss drone sets `isBoss`.
>   - `basic_drone` laser `damage_range` reduced `6–10` -> `2–4`.
> - **Normalization**:
>   - Add `deepCopy` and use it across nested fields; preserve/pass through `enemy`, `variants`, `bounty`, `xpReward`, `energyRegen`, `isEnemy`, `isBoss`, and deep-copy `visuals`, `ai`, `cargo`, `equipmentLayout`, `hardpoints`, and `loot.drops`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa5fc9af6a862e59df49a69c190a50fa74c4e53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->