### PR TITLE
Align Mining Hotspots With Asteroid Colliders

### DIFF
--- a/src/components/collidable.lua
+++ b/src/components/collidable.lua
@@ -9,6 +9,18 @@ function Collidable.new(values)
     -- Preserve optional shape/vertices for polygon collisions
     instance.shape = values.shape or values.type
     instance.vertices = values.vertices
+    if (not instance.radius or instance.radius == 0) and instance.vertices then
+        local maxRadius = 0
+        for i = 1, #instance.vertices, 2 do
+            local vx = instance.vertices[i] or 0
+            local vy = instance.vertices[i + 1] or 0
+            local distance = math.sqrt(vx * vx + vy * vy)
+            if distance > maxRadius then
+                maxRadius = distance
+            end
+        end
+        instance.radius = maxRadius
+    end
     -- Optional gameplay metadata
     instance.friendly = values.friendly or false
     instance.signature = values.signature -- may be nil if not provided

--- a/src/components/hotspots.lua
+++ b/src/components/hotspots.lua
@@ -36,10 +36,43 @@ end
 local function generatePositionOnAsteroid(asteroid, radius)
     local pos = asteroid.components.position
     local collidable = asteroid.components.collidable
-    local bodyRadius = (collidable and collidable.radius) or radius or 24
+    local hotspotRadius = radius or 12
 
+    if collidable and collidable.shape == "polygon" and collidable.vertices and #collidable.vertices >= 6 then
+        local vertexCount = math.floor(#collidable.vertices / 2)
+        if vertexCount >= 3 then
+            local index = math.random(1, vertexCount)
+            local nextIndex = (index % vertexCount) + 1
+
+            local vx = collidable.vertices[(index - 1) * 2 + 1] or 0
+            local vy = collidable.vertices[(index - 1) * 2 + 2] or 0
+            local nx = collidable.vertices[(nextIndex - 1) * 2 + 1] or 0
+            local ny = collidable.vertices[(nextIndex - 1) * 2 + 2] or 0
+
+            local t = math.random()
+            local edgeX = vx + (nx - vx) * t
+            local edgeY = vy + (ny - vy) * t
+
+            local length = math.sqrt(edgeX * edgeX + edgeY * edgeY)
+            local dirX, dirY = 0, -1
+            if length > 0 then
+                dirX = edgeX / length
+                dirY = edgeY / length
+            end
+
+            local offset = hotspotRadius * 0.6
+            local jitter = (math.random() - 0.5) * hotspotRadius * 0.1
+
+            local x = pos.x + edgeX + dirX * (hotspotRadius + offset) + (-dirY) * jitter
+            local y = pos.y + edgeY + dirY * (hotspotRadius + offset) + dirX * jitter
+
+            return x, y
+        end
+    end
+
+    local bodyRadius = (collidable and collidable.radius) or hotspotRadius or 24
     local angle = math.random() * math.pi * 2
-    local distance = bodyRadius * (1.0 + math.random() * 0.05)
+    local distance = bodyRadius + hotspotRadius * 0.65
 
     local x = pos.x + math.cos(angle) * distance
     local y = pos.y + math.sin(angle) * distance

--- a/src/systems/render/entity_renderers.lua
+++ b/src/systems/render/entity_renderers.lua
@@ -322,36 +322,45 @@ function EntityRenderers.asteroid(entity, player)
                     -- Calculate pulsing effect
                     local pulse = 0.8 + 0.2 * math.sin(hotspot.pulsePhase)
                     local alpha = (hotspot.lifetime / hotspot.maxLifetime) * pulse
-                    
+
                     -- Calculate angle from asteroid center to hotspot
                     local dx = hotspot.x - asteroidX
                     local dy = hotspot.y - asteroidY
                     local angle = math.atan2(dy, dx)
-                    
-                    -- Calculate half circle parameters
+
+                    -- Calculate half circle parameters based on stored hotspot position
                     local halfCircleRadius = hotspot.radius * pulse
-                    local halfCircleX = asteroidX + math.cos(angle) * (asteroidRadius + halfCircleRadius * 0.5)
-                    local halfCircleY = asteroidY + math.sin(angle) * (asteroidRadius + halfCircleRadius * 0.5)
-                    
-                    -- Draw half circle as a filled arc
-                    local glowColor = {1.0, 0.8, 0.2, alpha * 0.6} -- Orange glow
+                    local baseDistance = math.sqrt(dx * dx + dy * dy)
+                    local desiredDistance = asteroidRadius + halfCircleRadius * 0.35
+                    local distance = baseDistance
+                    if distance <= 0 then
+                        distance = desiredDistance
+                    else
+                        distance = math.max(distance, desiredDistance)
+                    end
+
+                    local halfCircleX = asteroidX + math.cos(angle) * distance
+                    local halfCircleY = asteroidY + math.sin(angle) * distance
+
+                    -- Draw half circle as a filled arc with vivid yellow glow
+                    local glowColor = {1.0, 0.95, 0.35, alpha * 0.55}
                     RenderUtils.setColor(glowColor)
-                    love.graphics.arc("fill", halfCircleX, halfCircleY, halfCircleRadius, 
+                    love.graphics.arc("fill", halfCircleX, halfCircleY, halfCircleRadius,
                                    angle - math.pi/2, angle + math.pi/2, 32)
-                    
-                    -- Draw half circle border
-                    local borderColor = {1.0, 0.6, 0.0, alpha} -- Brighter orange border
+
+                    -- Draw half circle border with a brighter rim
+                    local borderColor = {1.0, 0.9, 0.2, alpha}
                     RenderUtils.setColor(borderColor)
                     love.graphics.setLineWidth(2)
-                    love.graphics.arc("line", halfCircleX, halfCircleY, halfCircleRadius, 
+                    love.graphics.arc("line", halfCircleX, halfCircleY, halfCircleRadius,
                                     angle - math.pi/2, angle + math.pi/2, 32)
                     love.graphics.setLineWidth(1)
-                    
-                    -- Draw inner core as smaller half circle
-                    local coreColor = {1.0, 1.0, 0.4, alpha * 0.8} -- Bright yellow core
+
+                    -- Draw inner core as smaller half circle to sell the heat
+                    local coreColor = {1.0, 0.98, 0.55, alpha * 0.85}
                     RenderUtils.setColor(coreColor)
-                    local coreRadius = halfCircleRadius * 0.4
-                    love.graphics.arc("fill", halfCircleX, halfCircleY, coreRadius, 
+                    local coreRadius = halfCircleRadius * 0.42
+                    love.graphics.arc("fill", halfCircleX, halfCircleY, coreRadius,
                                    angle - math.pi/2, angle + math.pi/2, 32)
                 end
             end


### PR DESCRIPTION
## Summary
- ensure polygon colliders expose a reliable radius for mining calculations
- spawn mining hotspots along asteroid hull geometry so they sit on the outer edge
- render hotspots at their stored positions with brighter yellow arcs for better visibility

## Testing
- not run (Love2D runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68db71dbef508322a175c94e6fcc9530

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute collider radius from polygon vertices, spawn hotspots along asteroid hull, and render them at stored positions with brighter, clearer arcs.
> 
> - **Mining/Collisions**:
>   - `src/components/collidable.lua`: Derive `radius` from polygon `vertices` when absent by using max vertex distance.
> - **Hotspot Spawning**:
>   - `src/components/hotspots.lua`: Place hotspots along polygon collider edges with offset/jitter; use `hotspotRadius` and refined distance (`bodyRadius + hotspotRadius * 0.65`).
> - **Rendering**:
>   - `src/systems/render/entity_renderers.lua`: Position half-circle hotspot visuals using stored hotspot coords and clamp distance from asteroid; tweak glow/border/core colors and core size for higher visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e8ad0063a4e1d829cd1edfcea1faa2b3592bec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->