### PR TITLE
Refine Collision Handling With Polygon Support

### DIFF
--- a/src/systems/collision/effects.lua
+++ b/src/systems/collision/effects.lua
@@ -2,6 +2,7 @@ local Effects = require("src.systems.effects")
 local Events = require("src.core.events")
 local Config = require("src.content.config")
 local StationShields = require("src.systems.collision.station_shields")
+local Radius = require("src.systems.collision.radius")
 
 local CollisionEffects = {}
 
@@ -113,7 +114,13 @@ function CollisionEffects.applyDamage(entity, damageValue, source)
         Effects.addDamageNumber(entity.components.position.x, entity.components.position.y, math.floor(shieldDamage), "shield")
     end
 
-    health.shield = math.max(0, shieldBefore - shieldDamage)
+    local newShield = math.max(0, shieldBefore - shieldDamage)
+    if newShield ~= shieldBefore then
+        health.shield = newShield
+        Radius.invalidateCache(entity)
+    else
+        health.shield = newShield
+    end
     local remainingDamage = incoming - shieldDamage
 
     if remainingDamage > 0 then

--- a/src/systems/collision/geometry.lua
+++ b/src/systems/collision/geometry.lua
@@ -1,5 +1,26 @@
 local Geometry = {}
 
+local function distSqPointSegment(px, py, x1, y1, x2, y2)
+  local dx, dy = x2 - x1, y2 - y1
+  if dx == 0 and dy == 0 then
+    local qx, qy = px - x1, py - y1
+    return qx * qx + qy * qy
+  end
+
+  local t = ((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy)
+  if t < 0 then
+    t = 0
+  elseif t > 1 then
+    t = 1
+  end
+
+  local projx = x1 + t * dx
+  local projy = y1 + t * dy
+  local qx = px - projx
+  local qy = py - projy
+  return qx * qx + qy * qy
+end
+
 function Geometry.segIntersect(x1,y1,x2,y2, x3,y3,x4,y4)
   local function cross(ax,ay,bx,by) return ax*by - ay*bx end
   local rpx, rpy = x2 - x1, y2 - y1
@@ -107,6 +128,31 @@ function Geometry.polygonVsPolygon(verts1, verts2)
 
   local numVertices2 = #verts2 / 2
   if numVertices2 >= 1 and Geometry.pointInPolygon(verts2[1], verts2[2], verts1) then
+    return true
+  end
+
+  return false
+end
+
+function Geometry.polygonVsCircle(verts, cx, cy, radius)
+  if not verts or #verts < 6 then return false end
+  local radiusSq = radius * radius
+  local numVertices = #verts / 2
+
+  for i = 1, numVertices do
+    local nextI = i + 1
+    if nextI > numVertices then nextI = 1 end
+    local x1 = verts[(i-1) * 2 + 1]
+    local y1 = verts[(i-1) * 2 + 2]
+    local x2 = verts[(nextI-1) * 2 + 1]
+    local y2 = verts[(nextI-1) * 2 + 2]
+
+    if distSqPointSegment(cx, cy, x1, y1, x2, y2) <= radiusSq then
+      return true
+    end
+  end
+
+  if Geometry.pointInPolygon(cx, cy, verts) then
     return true
   end
 

--- a/src/systems/collision/radius.lua
+++ b/src/systems/collision/radius.lua
@@ -2,58 +2,110 @@ local Config = require("src.content.config")
 
 local Radius = {}
 
+local HIT_BUFFER = (Config.BULLET and Config.BULLET.HIT_BUFFER) or 1.5
+local SHIELD_PADDING = 4
+local DEFAULT_PLAYER_RADIUS = 12
+local DEFAULT_ENTITY_RADIUS = 10
+
+local function baseRadius(entity)
+    local collidable = entity.components and entity.components.collidable
+    if collidable and collidable.radius and collidable.radius > 0 then
+        return collidable.radius
+    end
+    if entity.components and entity.components.player then
+        return DEFAULT_PLAYER_RADIUS
+    end
+    return DEFAULT_ENTITY_RADIUS
+end
+
+local function extentFromVertices(vertices)
+    local maxExtent = 0
+    if not vertices then return maxExtent end
+
+    if type(vertices[1]) == "table" then
+        for _, vertex in ipairs(vertices) do
+            local vx = vertex[1] or 0
+            local vy = vertex[2] or 0
+            local distance = math.sqrt(vx * vx + vy * vy)
+            if distance > maxExtent then
+                maxExtent = distance
+            end
+        end
+        return maxExtent
+    end
+
+    for i = 1, #vertices, 2 do
+        local vx = vertices[i] or 0
+        local vy = vertices[i + 1] or 0
+        local distance = math.sqrt(vx * vx + vy * vy)
+        if distance > maxExtent then
+            maxExtent = distance
+        end
+    end
+    return maxExtent
+end
+
 local function shapeExtent(shape, size)
     if not shape then return 0 end
     size = size or 1.0
+
     if shape.type == "rectangle" then
         local right = (shape.x or 0) + (shape.w or 0)
         local left = (shape.x or 0)
         local top = (shape.y or 0)
         local bottom = (shape.y or 0) + (shape.h or 0)
         local corners = {
-            math.sqrt(left*left + top*top),
-            math.sqrt(right*right + top*top),
-            math.sqrt(left*left + bottom*bottom),
-            math.sqrt(right*right + bottom*bottom)
+            math.sqrt(left * left + top * top),
+            math.sqrt(right * right + top * top),
+            math.sqrt(left * left + bottom * bottom),
+            math.sqrt(right * right + bottom * bottom)
         }
         local m = 0
-        for _, d in ipairs(corners) do m = math.max(m, d * size) end
+        for _, d in ipairs(corners) do
+            m = math.max(m, d * size)
+        end
         return m
     elseif shape.type == "polygon" and shape.points then
         local m = 0
         for i = 1, #shape.points, 2 do
-            local px, py = shape.points[i] or 0, shape.points[i+1] or 0
-            m = math.max(m, math.sqrt(px*px + py*py) * size)
+            local px = shape.points[i] or 0
+            local py = shape.points[i + 1] or 0
+            m = math.max(m, math.sqrt(px * px + py * py) * size)
         end
         return m
     elseif shape.type == "circle" then
         local cx, cy = shape.x or 0, shape.y or 0
         local r = shape.r or shape.radius or 0
-        return (math.sqrt(cx*cx + cy*cy) + r) * size
+        return (math.sqrt(cx * cx + cy * cy) + r) * size
     elseif shape.type == "ellipse" then
         local cx, cy = shape.x or 0, shape.y or 0
         local rx, ry = shape.rx or 0, shape.ry or 0
-        return (math.sqrt(cx*cx + cy*cy) + math.max(rx, ry)) * size
+        return (math.sqrt(cx * cx + cy * cy) + math.max(rx, ry)) * size
     end
+
     return 0
 end
 
-local function computeVisualRadius(entity)
-    local renderable = entity.components.renderable
+local function visualsShapes(visuals)
+    if type(visuals) ~= "table" then
+        return nil
+    end
+    if visuals.shapes then
+        return visuals.shapes
+    end
+    return visuals
+end
+
+function Radius.computeVisualRadius(entity)
+    local renderable = entity.components and entity.components.renderable
     if not renderable or not renderable.props or not renderable.props.visuals then
         return 0
     end
+
     local visuals = renderable.props.visuals
-    local size = (visuals.size or 1.0)
+    local size = visuals.size or 1.0
     local maxExtent = 0
 
-    -- Handle visuals as direct array of shapes (warp gates) or object with .shapes
-    local shapes = visuals
-    if type(visuals) == "table" and visuals.shapes then
-        shapes = visuals.shapes
-    end
-
-    -- Check for explicit radius (e.g., planets)
     if visuals.radius then
         maxExtent = math.max(maxExtent, visuals.radius * size)
     end
@@ -61,109 +113,90 @@ local function computeVisualRadius(entity)
         maxExtent = math.max(maxExtent, visuals.ringOuter * size)
     end
 
-    -- Compute from shapes if present (stations, asteroids, warp gates)
+    local shapes = visualsShapes(visuals)
     if shapes and type(shapes) == "table" then
         for _, shape in ipairs(shapes) do
-            if shape then
-                maxExtent = math.max(maxExtent, shapeExtent(shape, size))
-            end
+            maxExtent = math.max(maxExtent, shapeExtent(shape, size))
         end
     end
 
-    -- For asteroids with vertices (stored in props.vertices, not visuals.vertices)
     if renderable.props and renderable.props.vertices then
-        for _, vertex in ipairs(renderable.props.vertices) do
-            local vx, vy = vertex[1] or 0, vertex[2] or 0
-            maxExtent = math.max(maxExtent, math.sqrt(vx*vx + vy*vy) * size)
-        end
+        maxExtent = math.max(maxExtent, extentFromVertices(renderable.props.vertices) * size)
     end
-    
-    -- Also check visuals.vertices for other entities
+
     if visuals.vertices then
-        for _, vertex in ipairs(visuals.vertices) do
-            local vx, vy = vertex[1] or 0, vertex[2] or 0
-            maxExtent = math.max(maxExtent, math.sqrt(vx*vx + vy*vy) * size)
-        end
+        maxExtent = math.max(maxExtent, extentFromVertices(visuals.vertices) * size)
     end
 
     return maxExtent
 end
 
-local function computeShieldRadius(entity)
-    local renderable = entity.components.renderable
+function Radius.getHullRadius(entity)
+    local radius = baseRadius(entity)
+    local collidable = entity.components and entity.components.collidable
+
+    if collidable and collidable.vertices then
+        radius = math.max(radius, extentFromVertices(collidable.vertices))
+    end
+
+    radius = math.max(radius, Radius.computeVisualRadius(entity))
+
+    if entity.components and entity.components.mineable then
+        radius = math.max(radius, baseRadius(entity))
+    end
+
+    return radius
+end
+
+function Radius.getShieldRadius(entity)
+    local renderable = entity.components and entity.components.renderable
     if renderable and renderable.props and renderable.props.visuals then
         local visuals = renderable.props.visuals
         local size = visuals.size or 1.0
-        -- If cache matches current visuals.size, return cached value
         if entity.shieldRadius and entity._shieldRadiusVisualSize == size then
             return entity.shieldRadius
         end
         local maxExtent = 0
-        if visuals.shapes and type(visuals.shapes) == "table" then
-            for _, shape in ipairs(visuals.shapes) do
-                maxExtent = math.max(maxExtent, shapeExtent(shape, size))
-            end
-        end
-        if maxExtent > 0 then
-            local r = maxExtent + 4 -- doubled padding for clearer shield collision margin
-            entity.shieldRadius = r
-            entity._shieldRadiusVisualSize = size
-            return r
-        end
-    end
-    local baseRadius = entity.components.collidable.radius or (entity.components.player and 12 or 10)
-    return math.max(baseRadius * 2, baseRadius + 12)
-end
 
-local function computeHullRadius(entity)
-    -- Use visuals to estimate true hull extent when shields are down
-    local renderable = entity.components.renderable
-    if renderable and renderable.props and renderable.props.visuals then
-        local visuals = renderable.props.visuals
-        local size = visuals.size or 1.0
-        local maxExtent = 0
-        if visuals.shapes and type(visuals.shapes) == "table" then
-            for _, shape in ipairs(visuals.shapes) do
+        local shapes = visualsShapes(visuals)
+        if shapes and type(shapes) == "table" then
+            for _, shape in ipairs(shapes) do
                 maxExtent = math.max(maxExtent, shapeExtent(shape, size))
             end
         end
+
         if maxExtent > 0 then
-            -- Hull radius approximates true model extent (no extra shield padding)
-            local baseRadius = entity.components.collidable.radius or (entity.components.player and 12 or 10)
-            return math.max(baseRadius, maxExtent)
+            local radius = math.max(Radius.getHullRadius(entity), maxExtent + SHIELD_PADDING)
+            entity.shieldRadius = radius
+            entity._shieldRadiusVisualSize = size
+            return radius
         end
     end
-    return entity.components.collidable.radius or (entity.components.player and 12 or 10)
+
+    local base = baseRadius(entity)
+    local fallback = math.max(base * 2, base + 12)
+    entity.shieldRadius = fallback
+    entity._shieldRadiusVisualSize = nil
+    return fallback
 end
 
 function Radius.calculateEffectiveRadius(entity)
-    local baseRadius = entity.components.collidable.radius or (entity.components.player and 12 or 10)
-    local hitBuffer = (Config.BULLET and Config.BULLET.HIT_BUFFER) or 1.5
-
-    if entity.components.mineable then
-        -- For mineable entities (asteroids), use visual radius to ensure proper collision
-        local visualRadius = computeVisualRadius(entity)
-        local collidableRadius = entity.components.collidable.radius or baseRadius
-        local effectiveRadius = math.max(visualRadius, collidableRadius)
-        local finalRadius = effectiveRadius + hitBuffer
-        print("Radius calculation for asteroid: visual=" .. visualRadius .. ", collidable=" .. collidableRadius .. ", effective=" .. effectiveRadius .. ", final=" .. finalRadius)
-        return finalRadius
+    local effective = Radius.getHullRadius(entity)
+    local health = entity.components and entity.components.health
+    if health and (health.shield or 0) > 0 then
+        effective = math.max(effective, Radius.getShieldRadius(entity))
     end
-
-    -- Compute visual radius for broad-phase culling (covers large renderables like planets/stations/asteroids)
-    local visualRadius = computeVisualRadius(entity)
-    local effectiveVisual = math.max(baseRadius, visualRadius)
-
-    -- Use expanded, visually-accurate shield radius if entity has shields
-    if entity.components.health and (entity.components.health.shield or 0) > 0 then
-        local shieldRadius = computeShieldRadius(entity)
-        return math.max(effectiveVisual, (shieldRadius > 0 and shieldRadius or baseRadius)) + hitBuffer
-    else
-        -- When shields are gone, collide against visual hull extent
-        local hullRadius = computeHullRadius(entity)
-        return math.max(effectiveVisual, (hullRadius > 0 and hullRadius or baseRadius)) + hitBuffer
-    end
+    return effective + HIT_BUFFER
 end
 
-Radius.computeVisualRadius = computeVisualRadius
+function Radius.invalidateCache(entity, opts)
+    opts = opts or {}
+    entity._radiusCacheVersion = (entity._radiusCacheVersion or 0) + 1
+    if opts.visual then
+        entity._visualRadiusCacheVersion = (entity._visualRadiusCacheVersion or 0) + 1
+    end
+    entity.shieldRadius = nil
+    entity._shieldRadiusVisualSize = nil
+end
+
 return Radius


### PR DESCRIPTION
## Summary
- add reusable hull and shield radius helpers with cache invalidation hooks
- prefer polygon-aware intersection checks for entity collision tests and resolution
- extend collision geometry utilities with polygon-versus-circle support for narrow phase

## Testing
- `luac -p src/systems/collision/radius.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68dbf75f34448322bcc46d65243253dc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce polygon-aware collision checks, new hull/shield radius helpers (with caching/invalidation), and invalidate radius on shield updates.
> 
> - **Collision System**:
>   - Replace circle-only checks with polygon-aware narrow phase in `src/systems/collision/entity_collision.lua` using `Geometry.polygonVsPolygon` and `polygonVsCircle`; fall back to circle-circle.
>   - Compute collision shapes per-entity (shielded circle vs hull polygon/circle) and use hull/shield radii for overlap; squared-distance optimization for circles.
>   - Restitution now uses unified `hasActiveShield`; minor refactor of helper functions.
> - **Geometry Utilities (`src/systems/collision/geometry.lua`)**:
>   - Add `polygonVsCircle` and internal point-to-segment distance helper; expose `transformPolygon` usage for world-space verts.
> - **Radius Utilities (`src/systems/collision/radius.lua`)**:
>   - Add `getHullRadius`, `getShieldRadius` (with padding and caching), `calculateEffectiveRadius` (uses HIT_BUFFER), and `computeVisualRadius` improvements.
>   - Add `invalidateCache(entity[, opts])` to reset cached radii; remove legacy/verbose calculations.
> - **Collision Effects (`src/systems/collision/effects.lua`)**:
>   - Invalidate radius cache when shields change to keep radii in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e88601333317ad8535d9eca5a6aea9cc50be5929. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->