### PR TITLE
Expose Schema Builder On ConfigValidator

### DIFF
--- a/src/core/config_validator.lua
+++ b/src/core/config_validator.lua
@@ -592,4 +592,6 @@ function ConfigValidator.logErrors(result)
     end
 end
 
+ConfigValidator.Schema = Schema
+
 return ConfigValidator


### PR DESCRIPTION
## Summary
- expose the Schema builder on the ConfigValidator module so callers can access it directly

## Testing
- lua src/core/config_validator_test.lua *(fails: `lua` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dc08f06d20832286933092d963160e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose the `Schema` builder by attaching it to `ConfigValidator` as `ConfigValidator.Schema`.
> 
> - **Core**:
>   - Export `Schema` by assigning it to `ConfigValidator.Schema` in `src/core/config_validator.lua`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab58992885454ea213b9a713071f40507069ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->