### PR TITLE
Add XP pickups and adjust skill popup

### DIFF
--- a/content/sounds/sounds.lua
+++ b/content/sounds/sounds.lua
@@ -74,6 +74,7 @@ return {
     
     -- Pickup events
     loot_collected = {type = "sfx", sound = "loot_pickup", volume = 0.5},
+    xp_collected = {type = "sfx", sound = "loot_pickup", volume = 0.55, pitch = 1.1},
     asteroid_shatter = {type = "sfx", sound = "asteroid_shatter", volume = 0.65},
     
     -- UI events

--- a/src/entities/xp_pickup.lua
+++ b/src/entities/xp_pickup.lua
@@ -1,0 +1,29 @@
+local Position = require("src.components.position")
+local Renderable = require("src.components.renderable")
+local TimedLife = require("src.components.timed_life")
+
+local ExperiencePickup = {}
+
+local DEFAULT_LIFETIME = 150
+
+function ExperiencePickup.new(x, y, amount, sizeScale, vx, vy)
+    local self = { components = {} }
+
+    self.components.position = Position.new({ x = x, y = y })
+    self.components.renderable = Renderable.new({
+        type = "xp_pickup",
+        props = {
+            amount = amount or 0,
+            sizeScale = sizeScale or 1.0,
+        }
+    })
+    self.components.xp_pickup = { amount = amount or 0 }
+    self.components.velocity = { vx = vx or 0, vy = vy or 0 }
+    self.components.timed_life = TimedLife.new(DEFAULT_LIFETIME)
+
+    self.amount = amount or 0
+
+    return self
+end
+
+return ExperiencePickup

--- a/src/systems/pickups.lua
+++ b/src/systems/pickups.lua
@@ -1,11 +1,35 @@
 local Pickups = {}
-local Events = require("src.core.events")
 local Sound = require("src.core.sound")
 local Notifications = require("src.ui.notifications")
 
 local ATTRACT_RADIUS = 600  -- Increased from 400 to 600 for better item collection
 local CAPTURE_RADIUS = 35  -- Increased to ensure items are collected when they get under the ship
 local BASE_PULL = 180
+
+local function formatAmount(value)
+  if math.abs(value - math.floor(value + 0.5)) < 0.05 then
+    return tostring(math.floor(value + 0.5))
+  end
+  return string.format("%.1f", value)
+end
+
+local function gatherPickups(world, ...)
+  local results = {}
+  local sources = {
+    world:get_entities_with_components("item_pickup", ...),
+    world:get_entities_with_components("xp_pickup", ...)
+  }
+
+  for _, list in ipairs(sources) do
+    if list then
+      for _, entity in ipairs(list) do
+        table.insert(results, entity)
+      end
+    end
+  end
+
+  return results
+end
 
 local function dist(x1,y1,x2,y2)
   local dx,dy = x2-x1,y2-y1
@@ -14,18 +38,33 @@ end
 
 local function collect(player, pickup)
   if not pickup or not player then return end
+
+  local position = pickup.components and pickup.components.position
+  local xpComponent = pickup.components and pickup.components.xp_pickup
+  if xpComponent and player.addXP then
+    local amount = xpComponent.amount or pickup.amount or 0
+    if amount > 0 then
+      player:addXP(amount)
+      Sound.triggerEventAt("xp_collected", position and position.x, position and position.y)
+      Notifications.action("+" .. formatAmount(amount) .. " XP")
+    end
+    pickup.dead = true
+    return
+  end
+
   local cargo = player.components and player.components.cargo
   if not cargo then return end
+
   local id = pickup.itemId or (pickup.components and pickup.components.renderable and pickup.components.renderable.props and pickup.components.renderable.props.itemId) or "stones"
   local qty = pickup.qty or (pickup.components and pickup.components.renderable and pickup.components.renderable.props and pickup.components.renderable.props.qty) or 1
   cargo:add(id, qty)
-  Sound.triggerEventAt("loot_collected", pickup.components.position.x, pickup.components.position.y)
-  
+  Sound.triggerEventAt("loot_collected", position and position.x or pickup.components.position.x, position and position.y or pickup.components.position.y)
+
   -- Show pickup notification
   local itemName = id == "stones" and "Raw Stones" or (id == "ore_tritanium" and "Tritanium Ore" or id)
-  local notificationText = qty > 1 and ("+" .. qty .. " " .. itemName) or ("+" .. qty .. " " .. itemName)
+  local notificationText = "+" .. qty .. " " .. itemName
   Notifications.action(notificationText)
-  
+
   pickup.dead = true
 end
 
@@ -34,7 +73,7 @@ function Pickups.update(dt, world, player)
   local px, py = player.components.position.x, player.components.position.y
 
   -- Update all pickups with velocity and drag
-  for _, e in ipairs(world:get_entities_with_components("item_pickup", "position", "velocity")) do
+  for _, e in ipairs(gatherPickups(world, "position", "velocity")) do
     if not e.dead then
       local vel = e.components.velocity
       local pos = e.components.position
@@ -49,7 +88,7 @@ function Pickups.update(dt, world, player)
 
   -- Make player ship magnetic - attract ALL nearby items
   local nearbyItems = {}
-  for _, e in ipairs(world:get_entities_with_components("item_pickup", "position")) do
+  for _, e in ipairs(gatherPickups(world, "position")) do
     if not e.dead then
       local ex, ey = e.components.position.x, e.components.position.y
       local d = dist(ex, ey, px, py)

--- a/src/systems/render/entity_renderers.lua
+++ b/src/systems/render/entity_renderers.lua
@@ -31,6 +31,8 @@ local function getEntityRendererType(entity)
             entity._rendererType = 'asteroid'
         elseif entity.isItemPickup or entity.components.item_pickup then
             entity._rendererType = 'item_pickup'
+        elseif entity.components.xp_pickup then
+            entity._rendererType = 'xp_pickup'
         elseif entity.components.wreckage then
             entity._rendererType = 'wreckage'
         elseif entity.components.lootable and entity.isWreckage then
@@ -271,6 +273,46 @@ function EntityRenderers.item_pickup(entity, player)
         love.graphics.print(label, -textW/2, (size + 2)/textScale)
         love.graphics.pop()
     end
+
+    if oldFont then
+        love.graphics.setFont(oldFont)
+    end
+end
+
+function EntityRenderers.xp_pickup(entity, player)
+    local props = entity.components.renderable.props or {}
+    local Theme = require("src.core.theme")
+    local time = love.timer.getTime()
+    entity._pulseOffset = entity._pulseOffset or math.random() * math.pi * 2
+
+    local baseRadius = 9 * (props.sizeScale or 1.0)
+    local pulse = 0.75 + 0.25 * math.sin(time * 4 + entity._pulseOffset)
+    local glowRadius = baseRadius * (1.4 + 0.2 * math.sin(time * 3.2 + entity._pulseOffset * 0.5))
+
+    local xpColor = Theme.semantic and Theme.semantic.modernStatusXP or {0.45, 0.75, 1.0, 1.0}
+    local glowColor = {xpColor[1], xpColor[2], xpColor[3], 0.35}
+
+    love.graphics.setColor(glowColor)
+    love.graphics.circle("fill", 0, 0, glowRadius)
+
+    love.graphics.setColor(xpColor[1], xpColor[2], xpColor[3], 0.85)
+    love.graphics.circle("fill", 0, 0, baseRadius * pulse)
+
+    love.graphics.setColor(1.0, 1.0, 1.0, 0.95)
+    love.graphics.setLineWidth(1)
+    love.graphics.circle("line", 0, 0, baseRadius * (0.85 + 0.15 * pulse))
+
+    local oldFont = love.graphics.getFont()
+    if Theme.fonts and Theme.fonts.small then
+        love.graphics.setFont(Theme.fonts.small)
+    end
+
+    local font = love.graphics.getFont()
+    local label = "XP"
+    local labelW = font:getWidth(label)
+    local labelH = font:getHeight()
+    love.graphics.setColor(1.0, 1.0, 1.0, 0.9)
+    love.graphics.print(label, -labelW * 0.5, -labelH * 0.5)
 
     if oldFont then
         love.graphics.setFont(oldFont)
@@ -1035,6 +1077,8 @@ function EntityRenderers.draw(world, camera, player)
                 renderer = EntityRenderers.asteroid
             elseif rendererType == 'item_pickup' then
                 renderer = EntityRenderers.item_pickup
+            elseif rendererType == 'xp_pickup' then
+                renderer = EntityRenderers.xp_pickup
             elseif rendererType == 'wreckage' then
                 renderer = EntityRenderers.wreckage
             elseif rendererType == 'bullet' then

--- a/src/systems/turret/utility_beams.lua
+++ b/src/systems/turret/utility_beams.lua
@@ -6,6 +6,7 @@ local Effects = require("src.systems.effects")
 local Skills = require("src.core.skills")
 local Notifications = require("src.ui.notifications")
 local Events = require("src.core.events")
+local ExperiencePickup = require("src.entities.xp_pickup")
 
 local UtilityBeams = {}
 local IMPACT_INTERVAL = 0.18
@@ -25,6 +26,30 @@ local function spawnSalvagePickup(target, amount, world)
         target.components.position.y,
         "scraps",
         amount
+    )
+
+    if pickup then
+        world:addEntity(pickup)
+    end
+end
+
+local function spawnExperiencePickup(world, x, y, amount)
+    if not world or not amount or amount <= 0 then
+        return
+    end
+
+    local angle = math.random() * math.pi * 2
+    local offset = 8 + math.random() * 18
+    local speed = 40 + math.random() * 55
+    local spawnX = x + math.cos(angle) * offset
+    local spawnY = y + math.sin(angle) * offset
+    local pickup = ExperiencePickup.new(
+        spawnX,
+        spawnY,
+        amount,
+        1.0,
+        math.cos(angle) * speed,
+        math.sin(angle) * speed
     )
 
     if pickup then
@@ -441,12 +466,15 @@ function UtilityBeams.applySalvageDamage(target, damage, source, world)
         spawnSalvagePickup(target, whole, world)
         
         -- Give XP and skill progression for salvaged resources
-        if source and source.addXP then
+        if source then
             local xpBase = 10 -- base XP per salvaged resource
             local salvagingLevel = Skills.getLevel("salvaging")
             local xpGain = xpBase * (1 + salvagingLevel * 0.06) -- mild scaling per level
             local leveledUp = Skills.addXp("salvaging", xpGain)
-            source:addXP(xpGain)
+            local pos = target.components and target.components.position
+            local px = pos and pos.x or 0
+            local py = pos and pos.y or 0
+            spawnExperiencePickup(world, px, py, xpGain)
 
             if leveledUp then
                 Notifications.action("Salvaging level up!")
@@ -471,12 +499,15 @@ function UtilityBeams.applySalvageDamage(target, damage, source, world)
             spawnSalvagePickup(target, remainingToDrop, world)
             
             -- Give XP for remaining resources
-            if source and source.addXP then
+            if source then
                 local xpBase = 10
                 local salvagingLevel = Skills.getLevel("salvaging")
                 local xpGain = xpBase * (1 + salvagingLevel * 0.06) * remainingToDrop
                 local leveledUp = Skills.addXp("salvaging", xpGain)
-                source:addXP(xpGain)
+                local pos = target.components and target.components.position
+                local px = pos and pos.x or 0
+                local py = pos and pos.y or 0
+                spawnExperiencePickup(world, px, py, xpGain)
 
                 if leveledUp then
                     Notifications.action("Salvaging level up!")

--- a/src/ui/hud/skill_xp_popup.lua
+++ b/src/ui/hud/skill_xp_popup.lua
@@ -110,11 +110,11 @@ function SkillXpPopup.draw()
     end
 
     local sw, sh = Viewport.getDimensions()
-    local width = math.min(360, sw - 40)
-    local height = 94
-    local margin = 20
+    local width = math.min(320, sw - 32)
+    local height = 72
+    local margin = 16
     local x = sw - width - margin
-    local y = 120
+    local y = 36
 
     local alpha = SkillXpPopup.alpha
 
@@ -144,10 +144,10 @@ function SkillXpPopup.draw()
     Theme.setColor(Theme.withAlpha(Theme.colors.accent, alpha))
     love.graphics.print(xpGainText, x + width - xpGainMetrics.width - 16, y + 14)
 
-    local barX = x + 16
-    local barY = y + height - 36
-    local barW = width - 32
-    local barH = 14
+    local barX = x + 14
+    local barY = y + height - 28
+    local barW = width - 28
+    local barH = 12
 
     drawProgressBar(barX, barY, barW, barH, SkillXpPopup.state.progress, alpha)
 
@@ -164,7 +164,7 @@ function SkillXpPopup.draw()
     end
 
     Theme.setColor(Theme.withAlpha(Theme.colors.textSecondary or Theme.colors.text, alpha))
-    love.graphics.print(infoText, barX, barY + barH + 6)
+    love.graphics.print(infoText, barX, barY + barH + 4)
 
     if oldFont then
         love.graphics.setFont(oldFont)


### PR DESCRIPTION
## Summary
- add collectible XP droplets that spawn from mining and salvaging rewards, including new pickup entity, renderer, and sound hook
- update pickup handling so XP orbs magnetize to the player and award XP upon collection
- shrink and move the skill XP notification popup closer to the top of the HUD

## Testing
- not run (Love2D runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc0b1487f88322a6fdc977bda7115a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces collectible XP pickups spawned from mining and salvaging, updates pickup/renderer/audio handling, and compacts/repositions the skill XP HUD popup.
> 
> - **Gameplay**:
>   - Add `src/entities/xp_pickup.lua` entity and spawn XP orbs in `mining.lua` and `utility_beams.lua` instead of directly adding XP.
>   - Update `src/systems/pickups.lua` to attract and collect `xp_pickup` alongside `item_pickup`, granting XP with notifications.
> - **Rendering**:
>   - Add `xp_pickup` renderer and routing in `src/systems/render/entity_renderers.lua`.
> - **Audio**:
>   - Add `events.xp_collected` mapping in `content/sounds/sounds.lua`; trigger on XP collection.
> - **UI**:
>   - Shrink, reposition, and tweak paddings/bar sizes in `src/ui/hud/skill_xp_popup.lua`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf42c8d9eaa3759861c7fa8993f0440b7087a7b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->