### PR TITLE
Add Ore Furnace Station Near Hub

### DIFF
--- a/content/world_objects/ore_furnace_station.lua
+++ b/content/world_objects/ore_furnace_station.lua
@@ -1,0 +1,63 @@
+-- Data definition for an industrial ore-processing furnace station.
+return {
+    id = "ore_furnace_station",
+    name = "Helios Forge Complex",
+    class = "WorldObject",
+
+    renderable = {
+        type = "station",
+        props = {
+            size = "colossal",
+        }
+    },
+
+    -- Specialized services exposed through the station template
+    station_services = {
+        ore_processing = true,
+        stone_cracking = true,
+    },
+
+    description = "A sprawling refinery that superheats ore shipments into refined alloys.",
+
+    visuals = {
+        size = 6.0,
+        shapes = {
+            -- Outer thermal shield ring
+            { type = "circle", mode = "line", color = {0.95, 0.45, 0.05, 0.75}, x = 0, y = 0, r = 48, width = 6 },
+            { type = "circle", mode = "line", color = {0.40, 0.12, 0.02, 0.6}, x = 0, y = 0, r = 60, width = 3 },
+
+            -- Massive heat exchanger arms
+            { type = "rectangle", mode = "fill", color = {0.55, 0.58, 0.65, 0.85}, x = -80, y = -6, w = 160, h = 12, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.55, 0.58, 0.65, 0.85}, x = -6, y = -80, w = 12, h = 160, rx = 3 },
+            { type = "rectangle", mode = "fill", color = {0.45, 0.48, 0.55, 0.8}, x = -56, y = -4, w = 112, h = 8, rx = 3, rotation = 0.785 },
+            { type = "rectangle", mode = "fill", color = {0.45, 0.48, 0.55, 0.8}, x = -56, y = 0, w = 112, h = 8, rx = 3, rotation = -0.785 },
+
+            -- Core furnace chamber
+            { type = "circle", mode = "fill", color = {0.95, 0.65, 0.10, 0.95}, x = 0, y = 0, r = 36 },
+            { type = "circle", mode = "fill", color = {0.40, 0.10, 0.02, 0.9}, x = 0, y = 0, r = 22 },
+            { type = "circle", mode = "line", color = {1.0, 0.85, 0.35, 0.9}, x = 0, y = 0, r = 22, width = 4 },
+
+            -- Feedstock intake conduits
+            { type = "rectangle", mode = "fill", color = {0.30, 0.32, 0.38, 0.9}, x = 82, y = -10, w = 30, h = 20, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.30, 0.32, 0.38, 0.9}, x = -112, y = -10, w = 30, h = 20, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.30, 0.32, 0.38, 0.9}, x = -10, y = 82, w = 20, h = 30, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.30, 0.32, 0.38, 0.9}, x = -10, y = -112, w = 20, h = 30, rx = 4 },
+
+            -- Exhaust radiators with glowing vents
+            { type = "rectangle", mode = "fill", color = {0.22, 0.24, 0.30, 0.9}, x = 108, y = -18, w = 24, h = 36, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.24, 0.30, 0.9}, x = -132, y = -18, w = 24, h = 36, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.24, 0.30, 0.9}, x = -18, y = 108, w = 36, h = 24, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.22, 0.24, 0.30, 0.9}, x = -18, y = -132, w = 36, h = 24, rx = 4 },
+            { type = "rectangle", mode = "fill", color = {0.95, 0.45, 0.05, 0.8}, x = 112, y = -6, w = 16, h = 12 },
+            { type = "rectangle", mode = "fill", color = {0.95, 0.45, 0.05, 0.8}, x = -128, y = -6, w = 16, h = 12 },
+            { type = "rectangle", mode = "fill", color = {0.95, 0.45, 0.05, 0.8}, x = -6, y = 112, w = 12, h = 16 },
+            { type = "rectangle", mode = "fill", color = {0.95, 0.45, 0.05, 0.8}, x = -6, y = -128, w = 12, h = 16 },
+
+            -- Docking pylons for freighters
+            { type = "circle", mode = "fill", color = {0.60, 0.85, 1.0, 0.9}, x = 96, y = 0, r = 8 },
+            { type = "circle", mode = "fill", color = {0.60, 0.85, 1.0, 0.9}, x = -96, y = 0, r = 8 },
+            { type = "circle", mode = "fill", color = {0.60, 0.85, 1.0, 0.9}, x = 0, y = 96, r = 8 },
+            { type = "circle", mode = "fill", color = {0.60, 0.85, 1.0, 0.9}, x = 0, y = -96, r = 8 },
+        }
+    },
+}

--- a/src/content/normalizer.lua
+++ b/src/content/normalizer.lua
@@ -138,6 +138,13 @@ function Normalizer.normalizeWorldObject(def)
     out.no_spawn_radius = def.no_spawn_radius
   end
 
+  if def.station_services then
+    out.station_services = copy(def.station_services)
+  end
+  if def.description then
+    out.description = def.description
+  end
+
   return out
 end
 

--- a/src/core/ui.lua
+++ b/src/core/ui.lua
@@ -111,6 +111,19 @@ function UI.drawHelpers(player, world, hub, camera)
               -- Repaired beacon station
               text = "Beacon Array - OPERATIONAL"
             end
+          elseif station.components.station and station.components.station.type == "ore_furnace_station" then
+            local lines = { station.components.station.name or "Ore Furnace" }
+            local services = station.components.station.services
+            if services and type(services) == "table" then
+              local serviceNames = {}
+              if services.ore_processing then table.insert(serviceNames, "Ore Smelting") end
+              if services.stone_cracking then table.insert(serviceNames, "Stone Cracking") end
+              if #serviceNames > 0 then
+                table.insert(lines, table.concat(serviceNames, " • "))
+              end
+            end
+            table.insert(lines, "Automated refinery operations active")
+            text = table.concat(lines, "\n")
           elseif station == hub then
             -- Show docking prompt only for hub station
             local dockKey = (keymap and keymap.dock or "space"):upper()

--- a/src/game.lua
+++ b/src/game.lua
@@ -178,6 +178,15 @@ function Game.load(fromSave, saveSlot, loadingScreen)
     return false
   end
 
+  -- Create an industrial furnace station near the hub for ore processing logistics
+  local furnace_station = EntityFactory.create("station", "ore_furnace_station", 6800, 5000)
+  if furnace_station then
+    world:addEntity(furnace_station)
+  else
+    Log.error("Failed to create ore furnace station")
+    return false
+  end
+
   -- Create a beacon station to protect the top-left quadrant from enemy spawning
   local beacon_station = EntityFactory.create("station", "beacon_station", 7500, 7500)
   if beacon_station then

--- a/src/templates/station.lua
+++ b/src/templates/station.lua
@@ -14,52 +14,62 @@ function Station.new(x, y, config)
     self.tag = "station"
     self.isStation = true
 
+    local visuals = config.visuals or (config.renderable and config.renderable.props and config.renderable.props.visuals)
+    visuals = visuals or {}
+
     self.components = {
         position = Position.new({ x = x, y = y }),
         station = {
             type = config.id,
-            name = config.name or "Station"
+            name = config.name or "Station",
+            services = config.station_services,
+            description = config.description,
         }
     }
 
-    if config.id == "hub_station" or config.id == "beacon_station" then
-        -- No collidable for stations (no physics collisions, handled by visuals for rendering culling)
-  
-        -- Store shield radius for zones (weapons disable, docking, amber ring)
-        self.radius = ModelUtil.calculateModelWidth(config.visuals)
-        self.weaponDisableRadius = self.radius * 1.5 -- Tighter ring for weapons
-        self.shieldRadius = self.radius * 5 -- Larger ring for spawn protection
+    -- Store descriptive fields on the entity for UI helpers
+    self.description = config.description
 
-        -- Special handling for beacon stations with custom no-spawn radius
-        if config.id == "beacon_station" then
-            if config.no_spawn_radius then
-                self.noSpawnRadius = config.no_spawn_radius
-            end
-            -- Repairable beacon station properties
-            if config.repairable then
-                self.repairable = true
-                self.broken = config.broken or false
-                self.repairCost = config.repair_cost or {}
-
-                -- Only apply no-spawn radius when repaired
-                if self.broken then
-                    self.noSpawnRadius = nil -- No protection when broken
-                end
-
-                -- Add repairable component
-                self.components.repairable = Repairable.new({
-                    broken = self.broken,
-                    repairCost = self.repairCost
-                })
-            else
-                self.repairable = false
-            end
-        end
-
-        self.components.renderable = Renderable.new("station", {
-            visuals = config.visuals
-        })
+    -- Determine spatial radii for station safe zones
+    self.radius = ModelUtil.calculateModelWidth(visuals)
+    if config.radius then
+        self.radius = config.radius
     end
+    self.weaponDisableRadius = config.weapon_disable_radius or (self.radius * 1.5)
+    self.shieldRadius = config.shield_radius or (self.radius * 5)
+
+    -- Special handling for beacon stations with custom no-spawn radius
+    if config.id == "beacon_station" then
+        if config.no_spawn_radius then
+            self.noSpawnRadius = config.no_spawn_radius
+        end
+        -- Repairable beacon station properties
+        if config.repairable then
+            self.repairable = true
+            self.broken = config.broken or false
+            self.repairCost = config.repair_cost or {}
+
+            -- Only apply no-spawn radius when repaired
+            if self.broken then
+                self.noSpawnRadius = nil -- No protection when broken
+            end
+
+            -- Add repairable component
+            self.components.repairable = Repairable.new({
+                broken = self.broken,
+                repairCost = self.repairCost
+            })
+        else
+            self.repairable = false
+        end
+    elseif config.no_spawn_radius then
+        -- Allow other stations to define custom no-spawn zones directly
+        self.noSpawnRadius = config.no_spawn_radius
+    end
+
+    self.components.renderable = Renderable.new("station", {
+        visuals = visuals
+    })
 
     return self
 end


### PR DESCRIPTION
## Summary
- add a Helios Forge Complex station definition with unique furnace visuals and ore-processing metadata
- generalize station template handling so services/description data propagate to in-world entities
- spawn the furnace station near the hub and surface helper text describing its automated refining role

## Testing
- not run (Love2D runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc1e87b22c83229b41f36205b5b8bd