### PR TITLE
Add Dock Button Helper Toggle

### DIFF
--- a/src/core/input.lua
+++ b/src/core/input.lua
@@ -13,6 +13,7 @@ local SkillsPanel = require("src.ui.skills")
 local Util = require("src.core.util")
 local Hotbar = require("src.systems.hotbar")
 local RepairSystem = require("src.systems.repair_system")
+local UI = require("src.core.ui")
 
 local Input = {}
 
@@ -298,6 +299,11 @@ function Input.love_mousepressed(x, y, button)
     if mainState.UIManager and mainState.UIManager.mousepressed(vx, vy, button) then
       return
     end
+
+    if UI.handleHelperMousePressed and UI.handleHelperMousePressed(vx, vy, button, gameState.player) then
+      return
+    end
+
     Input.mousepressed(vx, vy, button)
   end
 end


### PR DESCRIPTION
## Summary
- replace the hub docking helper with an on-screen Dock button that appears above the station when in range
- add an ellipsis toggle to collapse and expand the dock prompt and wire clicks into the existing dock request flow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dc241435e48322b9f2d78bbb2c0272