### PR TITLE
Add Reward Crates With Quest Keys

### DIFF
--- a/content/items/index.lua
+++ b/content/items/index.lua
@@ -1,9 +1,11 @@
 -- List of item definition modules. Add new files and require them here.
 return {
-  require("content.items.ore_tritanium"),
-  require("content.items.ore_palladium"),
-  require("content.items.stones"),
-  require("content.items.scraps"),
-  require("content.items.node_wallet"),
-  require("content.items.shield_module_basic"),
+    require("content.items.reward_crate"),
+    require("content.items.reward_crate_key"),
+    require("content.items.ore_tritanium"),
+    require("content.items.ore_palladium"),
+    require("content.items.stones"),
+    require("content.items.scraps"),
+    require("content.items.node_wallet"),
+    require("content.items.shield_module_basic"),
 }

--- a/content/items/reward_crate.lua
+++ b/content/items/reward_crate.lua
@@ -1,0 +1,27 @@
+return {
+    id = "reward_crate",
+    name = "Reward Crate",
+    type = "consumable",
+    rarity = "Common",
+    tier = 1,
+    stack = 5,
+    value = 0,
+    price = 0,
+    mass = 1.0,
+    volume = 1.0,
+    tags = { "crate", "reward", "consumable" },
+    description = "A sealed container that hums with latent energy. Use it while holding a reward key to crack it open.",
+    flavor = "The outer shell bears the insignia of forgotten contractors.",
+    consumable = true,
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.18, 0.2, 0.28, 1.0}, x = 6, y = 8, w = 20, h = 16, rx = 3, ry = 3 },
+            { type = "rectangle", mode = "line", color = {0.42, 0.46, 0.68, 1.0}, x = 6, y = 8, w = 20, h = 16, rx = 3, ry = 3, width = 2 },
+            { type = "rectangle", mode = "fill", color = {0.26, 0.3, 0.46, 1.0}, x = 6, y = 14, w = 20, h = 4 },
+            { type = "rectangle", mode = "fill", color = {0.95, 0.8, 0.3, 1.0}, x = 14, y = 9, w = 4, h = 14 },
+            { type = "rectangle", mode = "fill", color = {0.98, 0.9, 0.55, 1.0}, x = 14, y = 14, w = 4, h = 4 },
+            { type = "circle", mode = "fill", color = {0.9, 0.6, 0.2, 1.0}, x = 16, y = 20, r = 2 },
+        }
+    }
+}

--- a/content/items/reward_crate_key.lua
+++ b/content/items/reward_crate_key.lua
@@ -1,0 +1,25 @@
+return {
+    id = "reward_crate_key",
+    name = "Reward Key",
+    type = "material",
+    rarity = "Uncommon",
+    tier = 1,
+    stack = 20,
+    value = 0,
+    price = 0,
+    mass = 0.1,
+    volume = 0.05,
+    tags = { "key", "reward" },
+    description = "A precision-cut key that unlocks sealed reward crates found across the sector.",
+    flavor = "Its edges pulse faintly when a crate is nearby.",
+    icon = {
+        size = 32,
+        shapes = {
+            { type = "rectangle", mode = "fill", color = {0.86, 0.78, 0.32, 1.0}, x = 8, y = 14, w = 10, h = 4 },
+            { type = "rectangle", mode = "fill", color = {0.96, 0.9, 0.52, 1.0}, x = 14, y = 12, w = 10, h = 8, rx = 1, ry = 1 },
+            { type = "circle", mode = "line", color = {0.98, 0.95, 0.65, 1.0}, x = 24, y = 16, r = 4, width = 1.5 },
+            { type = "rectangle", mode = "fill", color = {0.7, 0.6, 0.2, 1.0}, x = 10, y = 12, w = 2, h = 2 },
+            { type = "rectangle", mode = "fill", color = {0.7, 0.6, 0.2, 1.0}, x = 10, y = 18, w = 2, h = 2 },
+        }
+    }
+}

--- a/content/ships/boss_drone.lua
+++ b/content/ships/boss_drone.lua
@@ -304,6 +304,7 @@ return {
 
   loot = {
     drops = {
+      { id = "reward_crate", min = 1, max = 1, chance = 1.0 },
       { id = "ore_tritanium", min = 3, max = 6, chance = 0.9 },
       { id = "basic_gun", chance = 0.6 },
     }

--- a/src/content/quest_generator.lua
+++ b/src/content/quest_generator.lua
@@ -31,7 +31,12 @@ local function buildKillQuest(opts)
     title = title,
     description = desc,
     objective = { type = "kill", target = target, count = count },
-    reward = { xp = rewardXP }
+    reward = {
+      xp = rewardXP,
+      items = {
+        { id = "reward_crate_key", qty = 1 }
+      }
+    }
   }
 end
 
@@ -49,7 +54,12 @@ local function buildMineQuest(opts)
     title = title,
     description = desc,
     objective = { type = "mine", target = target, count = count },
-    reward = { xp = rewardXP }
+    reward = {
+      xp = rewardXP,
+      items = {
+        { id = "reward_crate_key", qty = 1 }
+      }
+    }
   }
 end
 
@@ -67,7 +77,12 @@ local function buildSalvageQuest(opts)
     title = title,
     description = desc,
     objective = { type = "salvage", target = resource, count = count },
-    reward = { xp = rewardXP }
+    reward = {
+      xp = rewardXP,
+      items = {
+        { id = "reward_crate_key", qty = 1 }
+      }
+    }
   }
 end
 

--- a/src/content/quests.lua
+++ b/src/content/quests.lua
@@ -1,11 +1,17 @@
 local quests = {
-  {
-    id = "destroy_drones",
-    title = "Drone Menace",
-    description = "Destroy 5 basic drones.",
-    objective = { type = "kill", target = "basic_drone", count = 5 },
-    reward = { gc = 1000, xp = 100 }
-  }
+    {
+        id = "destroy_drones",
+        title = "Drone Menace",
+        description = "Destroy 5 basic drones.",
+        objective = { type = "kill", target = "basic_drone", count = 5 },
+        reward = {
+            gc = 1000,
+            xp = 100,
+            items = {
+                { id = "reward_crate_key", qty = 1 }
+            }
+        }
+    }
 }
 
 return quests

--- a/src/ui/quests.lua
+++ b/src/ui/quests.lua
@@ -38,7 +38,22 @@ local function drawRewardRow(quest, x, y)
     Theme.drawXPIcon(rewardX, y, iconSize)
     Theme.setColor(Theme.colors.success)
     love.graphics.print(quest.reward.xp, rewardX + 15, textY)
+    rewardX = rewardX + 60
   end
+  if quest.reward.items and #quest.reward.items > 0 then
+    Theme.setColor(Theme.colors.text)
+    for _, entry in ipairs(quest.reward.items) do
+      local itemId = entry.id
+      local qty = entry.qty or entry.count or entry.quantity or 1
+      if itemId then
+        local itemDef = Content.getItem(itemId)
+        local label = string.format("%dx %s", qty, (itemDef and itemDef.name) or itemId)
+        love.graphics.print(label, rewardX, textY)
+        rewardX = rewardX + love.graphics.getFont():getWidth(label) + 20
+      end
+    end
+  end
+  Theme.setColor(Theme.colors.text)
 end
 
 local function timeLeftText(seconds)


### PR DESCRIPTION
## Summary
- add reward crate and reward key item definitions and wire them into content loading
- grant quest turn-ins a key reward, surface item rewards in the UI, and let MILA drop a crate
- allow reward crates to consume a key for random credits and loot, with overflow dropped nearby

## Testing
- `luac -p content/items/index.lua content/items/reward_crate.lua content/items/reward_crate_key.lua content/ships/boss_drone.lua src/content/quest_generator.lua src/content/quests.lua src/systems/quest_system.lua src/ui/inventory.lua src/ui/quests.lua` *(fails: `luac` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dd579458a48322812cb9c5b5f3fa98

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `reward_crate` and `reward_crate_key`, add item rewards to quests, make boss drone drop crates, and enable opening crates for credits and random loot with UI support.
> 
> - **Content**:
>   - **Items**: Add `content/items/reward_crate.lua` and `content/items/reward_crate_key.lua`; load via `content/items/index.lua`.
>   - **Boss Loot**: `content/ships/boss_drone.lua` now drops `reward_crate`.
> - **Quests**:
>   - **Generation/Static**: `src/content/quest_generator.lua` and `src/content/quests.lua` grant `items` rewards (adds `reward_crate_key`).
>   - **System**: `src/systems/quest_system.lua` delivers `reward.items` to player inventory or spawns pickups on overflow.
>   - **UI**: `src/ui/quests.lua` renders item rewards alongside GC/XP.
> - **Inventory**:
>   - **Crate Use**: `src/ui/inventory.lua` allows using `reward_crate` (consumes `reward_crate_key`), grants random GC and item; drops pickup if inventory full.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0970a0fa7e6818d87a77959ea83d0a825a506ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->