### PR TITLE
Fix Missile Lock-On Guidance Parameters

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -87,14 +87,15 @@ local function spawn_projectile(x, y, angle, friendly, opts)
         -- Explicit projectile visual kind override (e.g., 'salvaging_laser')
         kind = opts.kind,
         -- Movement/Guidance overrides
-        speed_override = opts.speedOverride or opts.projectileSpeed,
-        homing_strength = opts.homingStrength,
+        speedOverride = opts.speedOverride or opts.projectileSpeed,
+        homingStrength = opts.homingStrength,
+        missileTurnRate = opts.missileTurnRate,
         target = opts.target or opts.guaranteedTarget,
-        guaranteed_hit = opts.guaranteedHit,
-        guaranteed_target = opts.guaranteedTarget,
+        guaranteedHit = opts.guaranteedHit,
+        guaranteedTarget = opts.guaranteedTarget,
         -- Visual overrides
-        tracer_width = opts.tracerWidth,
-        core_radius = opts.coreRadius,
+        tracerWidth = opts.tracerWidth,
+        coreRadius = opts.coreRadius,
         color = opts.color,
         impact = opts.impact,
         length = opts.length,


### PR DESCRIPTION
## Summary
- forward projectile guidance fields like homing strength and missile turn rate using the names expected by the projectile template
- allow missile launchers to acquire locks and home toward their targets again

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_b_68dd5dff763883229f42bb551ba456d8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename projectile option keys to camelCase and add missileTurnRate when spawning projectiles.
> 
> - **Gameplay/Core (`src/game.lua`)**:
>   - Update `spawn_projectile` to pass template options using camelCase keys:
>     - Movement/Guidance: `speedOverride`, `homingStrength`, `missileTurnRate`, `target`, `guaranteedHit`, `guaranteedTarget`.
>     - Visuals: `tracerWidth`, `coreRadius`, plus existing `color`, `impact`, `length`.
>   - Continue forwarding other options (`damage`, `kind`, `timed_life`, `source`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29525535c3fc886fc25ce2a2f581b4e53a08f446. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->