### PR TITLE
Improve missile lock-on feedback

### DIFF
--- a/src/core/ui.lua
+++ b/src/core/ui.lua
@@ -50,7 +50,7 @@ function UI.drawHUD(player, world, enemies, hub, wreckage, lootDrops, camera, re
   local overUI = UIManager.isMouseOverUI and UIManager.isMouseOverUI() or false
 
   if not overUI then
-    Reticle.draw(player)
+    Reticle.draw(player, camera)
   end
   Minimap.draw(player, world, enemies, hub, wreckage, lootDrops, remotePlayers, world:get_entities_with_components("mineable"))
   Hotbar.draw(player)


### PR DESCRIPTION
## Summary
- add configurable missile lock-on tolerance, grace, and decay handling for missile turrets
- allow the player targeting helper to keep and gracefully decay missile locks when the aim drifts slightly
- surface missile lock progress and the tracked target on the HUD reticle for clear feedback

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68dd711e15f08322b0cd88d3be4616ed