### PR TITLE
Add Target Lock Feedback Indicators

### DIFF
--- a/src/core/ui.lua
+++ b/src/core/ui.lua
@@ -50,7 +50,7 @@ function UI.drawHUD(player, world, enemies, hub, wreckage, lootDrops, camera, re
   local overUI = UIManager.isMouseOverUI and UIManager.isMouseOverUI() or false
 
   if not overUI then
-    Reticle.draw(player, camera)
+    Reticle.draw(player, world, camera)
   end
   Minimap.draw(player, world, enemies, hub, wreckage, lootDrops, remotePlayers, world:get_entities_with_components("mineable"))
   Hotbar.draw(player)

--- a/src/ui/hud/reticle.lua
+++ b/src/ui/hud/reticle.lua
@@ -129,7 +129,7 @@ local function colorByName(name)
   return T.accent
 end
 
-function Reticle.draw(player, camera)
+function Reticle.draw(player, world, camera)
   local mx, my = Viewport.getMousePosition()
   local t = love.timer.getTime()
 
@@ -147,6 +147,7 @@ function Reticle.draw(player, camera)
 
   -- Gather missile lock-on status/progress
   local lockInfo = Reticle.getMissileLockInfo(player)
+  local incomingLockInfo = Reticle.getIncomingLockInfo(player, world)
 
   love.graphics.push()
   -- Reticle draws in screen-space; make it crisp
@@ -172,6 +173,10 @@ function Reticle.draw(player, camera)
   -- Draw target marker in world space to show which enemy is being tracked
   if lockInfo.target and (lockInfo.progress > 0 or lockInfo.isLocked) then
     Reticle.drawTargetMarker(lockInfo, camera)
+  end
+
+  if incomingLockInfo.total > 0 then
+    Reticle.drawIncomingLockWarning(incomingLockInfo, player, camera)
   end
 end
 
@@ -239,6 +244,14 @@ function Reticle.drawLockOnIndicator(scale, progress, isLocked)
   end
 
   if not isLocked then
+    local prevFont = love.graphics.getFont()
+    if Theme.fonts and Theme.fonts.small then love.graphics.setFont(Theme.fonts.small) end
+    local font = love.graphics.getFont()
+    local label = "LOCKING"
+    Theme.setColor(Theme.withAlpha(Theme.colors.warning, 0.95))
+    local textW = font:getWidth(label)
+    love.graphics.print(label, -textW * 0.5, baseRadius + 6 * scale)
+    if prevFont then love.graphics.setFont(prevFont) end
     return
   end
 
@@ -262,6 +275,15 @@ function Reticle.drawLockOnIndicator(scale, progress, isLocked)
   drawBracket(1, -1)
   drawBracket(-1, 1)
   drawBracket(1, 1)
+
+  local prevFont = love.graphics.getFont()
+  if Theme.fonts and Theme.fonts.small then love.graphics.setFont(Theme.fonts.small) end
+  local font = love.graphics.getFont()
+  local label = "LOCKED"
+  Theme.setColor(Theme.withAlpha(Theme.colors.success, 0.95))
+  local textW = font:getWidth(label)
+  love.graphics.print(label, -textW * 0.5, baseRadius + 8 * scale)
+  if prevFont then love.graphics.setFont(prevFont) end
 end
 
 -- Draw marker over the world target that we're locking onto
@@ -322,6 +344,157 @@ function Reticle.drawTargetMarker(lockInfo, camera)
   end
 
   love.graphics.pop()
+end
+
+-- Scan the world for hostile turrets that are locking onto the player
+function Reticle.getIncomingLockInfo(player, world)
+  local info = {
+    total = 0,
+    lockedCount = 0,
+    highestProgress = 0,
+    threats = {},
+  }
+
+  if not world or not world.entities or not player then
+    return info
+  end
+
+  local function isHostile(entity)
+    if not entity or entity == player or entity.dead then return false end
+    if entity.isPlayer or entity.isFriendly then return false end
+    if entity.isEnemy or entity.isEnemyShip then return true end
+    local ai = entity.components and entity.components.ai
+    if ai then
+      if ai.aggressiveType and ai.aggressiveType == "neutral" then
+        return false
+      end
+      return true
+    end
+    return false
+  end
+
+  for _, entity in pairs(world.entities) do
+    if isHostile(entity) and entity.components and entity.components.equipment then
+      local grid = entity.components.equipment.grid
+      if grid then
+        for _, slot in ipairs(grid) do
+          if slot and slot.type == "turret" and slot.module then
+            local turret = slot.module
+            if turret.kind == "missile" and turret.lockOnTarget == player then
+              local progress = turret.lockOnProgress or 0
+              local locked = turret.isLockedOn or false
+              if locked then
+                progress = math.max(1.0, progress)
+                info.lockedCount = info.lockedCount + 1
+              end
+              info.total = info.total + 1
+              info.highestProgress = math.max(info.highestProgress, progress)
+              local threatPos
+              if entity.components and entity.components.position then
+                threatPos = {
+                  x = entity.components.position.x,
+                  y = entity.components.position.y,
+                }
+              end
+              table.insert(info.threats, {
+                entity = entity,
+                turret = turret,
+                progress = progress,
+                isLocked = locked,
+                position = threatPos,
+              })
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return info
+end
+
+local function drawDirectionIndicator(cx, cy, angle, color, locked, radius)
+  radius = radius or 200
+  local x = cx + math.cos(angle) * radius
+  local y = cy + math.sin(angle) * radius
+  local size = locked and 14 or 10
+
+  Theme.setColor(Theme.withAlpha(color, locked and 0.95 or 0.75))
+  love.graphics.push()
+  love.graphics.translate(x, y)
+  love.graphics.rotate(angle)
+  love.graphics.polygon('fill', 0, -size * 0.5, size, 0, 0, size * 0.5)
+  love.graphics.setLineWidth(2)
+  love.graphics.polygon('line', 0, -size * 0.5, size, 0, 0, size * 0.5)
+  love.graphics.pop()
+end
+
+function Reticle.drawIncomingLockWarning(info, player, camera)
+  if not info or info.total <= 0 or not player or not player.components then
+    return
+  end
+
+  local playerPos = player.components.position
+  if not playerPos then return end
+
+  local sw, sh = Viewport.getDimensions()
+  local camScale = (camera and camera.scale) or 1
+  local camX = (camera and camera.x) or 0
+  local camY = (camera and camera.y) or 0
+
+  local playerScreenX = (playerPos.x - camX) * camScale + sw * 0.5
+  local playerScreenY = (playerPos.y - camY) * camScale + sh * 0.5
+
+  local message = info.lockedCount > 0 and "MISSILE LOCKED" or "LOCK WARNING"
+  local color = info.lockedCount > 0 and Theme.colors.danger or Theme.colors.warning
+  local pulse = 0.65 + 0.35 * math.sin(love.timer.getTime() * 6)
+
+  local bannerWidth = 220
+  local bannerHeight = 34
+  local bannerX = math.floor(sw * 0.5 - bannerWidth * 0.5)
+  local bannerY = math.floor(sh * 0.12 - bannerHeight * 0.5)
+
+  Theme.setColor(Theme.withAlpha(color, pulse * 0.5))
+  love.graphics.rectangle('fill', bannerX, bannerY, bannerWidth, bannerHeight, 6, 6)
+  Theme.setColor(Theme.withAlpha(color, 0.95))
+  love.graphics.setLineWidth(2)
+  love.graphics.rectangle('line', bannerX, bannerY, bannerWidth, bannerHeight, 6, 6)
+  love.graphics.setLineWidth(1)
+
+  local prevFont = love.graphics.getFont()
+  if Theme.fonts and Theme.fonts.medium then love.graphics.setFont(Theme.fonts.medium) end
+  local font = love.graphics.getFont()
+  local textW = font:getWidth(message)
+  Theme.setColor({1, 1, 1, 0.95})
+  love.graphics.print(message, bannerX + (bannerWidth - textW) * 0.5, bannerY + 4)
+
+  local progress = math.max(0, math.min(1, info.highestProgress))
+  local barMargin = 12
+  local barX = bannerX + barMargin
+  local barY = bannerY + bannerHeight - 10
+  local barW = bannerWidth - barMargin * 2
+  local barH = 6
+
+  Theme.setColor(Theme.withAlpha({0, 0, 0}, 0.35))
+  love.graphics.rectangle('fill', barX, barY, barW, barH, 3, 3)
+  Theme.setColor(Theme.withAlpha(color, 0.9))
+  love.graphics.rectangle('fill', barX, barY, barW * progress, barH, 3, 3)
+
+  if prevFont then love.graphics.setFont(prevFont) end
+
+  local edgeRadius = math.min(sw, sh) * 0.35
+
+  for _, threat in ipairs(info.threats) do
+    if threat.position then
+      local sx = (threat.position.x - camX) * camScale + sw * 0.5
+      local sy = (threat.position.y - camY) * camScale + sh * 0.5
+      local dx = sx - playerScreenX
+      local dy = sy - playerScreenY
+      local angle = math.atan2(dy, dx)
+      local threatColor = threat.isLocked and Theme.colors.danger or Theme.colors.warning
+      drawDirectionIndicator(playerScreenX, playerScreenY, angle, threatColor, threat.isLocked, edgeRadius)
+    end
+  end
 end
 
 return Reticle


### PR DESCRIPTION
## Summary
- surface lock progress directly in the reticle with explicit locking/locked labels
- add HUD warning banner and directional cues when hostile missiles are locking onto the player
- pass the active world into the reticle draw path so it can detect hostile lock sources

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68dd7e8e853483228e15d74587189a80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the reticle with explicit LOCKING/LOCKED feedback and adds HUD warnings with directional indicators for incoming missile locks; updates UI to pass `world` to the reticle.
> 
> - **HUD/Reticle**:
>   - Reticle now accepts `Reticle.draw(player, world, camera)` and UI passes `world` from `src/core/ui.lua`.
>   - Displays explicit "LOCKING"/"LOCKED" labels around the cursor during missile target acquisition and lock.
>   - Adds world-aware incoming lock detection via `Reticle.getIncomingLockInfo(player, world)`.
>   - New HUD warning banner with progress bar and directional indicators for hostile missile locks using `Reticle.drawIncomingLockWarning` and `drawDirectionIndicator`.
>   - Keeps target marker drawing for locked/tracking targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075300b0241f284d047aaf536545bf93bbe0d896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->