### PR TITLE
Enable Physical Collisions For Stations

### DIFF
--- a/content/world_objects/beacon_station.lua
+++ b/content/world_objects/beacon_station.lua
@@ -11,7 +11,32 @@ return {
         }
     },
 
-    -- No collidable component for stations (no physics collisions)
+    collidable = {
+        shape = "polygon",
+        friendly = true,
+        vertices = {
+            6, -40,
+            -6, -40,
+            -6, -28,
+            -28, -28,
+            -28, -6,
+            -40, -6,
+            -40, 6,
+            -28, 6,
+            -28, 28,
+            -6, 28,
+            -6, 40,
+            6, 40,
+            6, 28,
+            28, 28,
+            28, 6,
+            40, 6,
+            40, -6,
+            28, -6,
+            28, -28,
+            6, -28,
+        }
+    },
 
     -- Repair system properties
     repairable = true,

--- a/content/world_objects/hub_station.lua
+++ b/content/world_objects/hub_station.lua
@@ -11,7 +11,32 @@ return {
         }
     },
 
-    -- No collidable component for stations (no physics collisions)
+    collidable = {
+        shape = "polygon",
+        friendly = true,
+        vertices = {
+            -100, -12,
+            -70, -12,
+            -70, -40,
+            -12, -40,
+            -12, -100,
+            12, -100,
+            12, -40,
+            70, -40,
+            70, -12,
+            100, -12,
+            100, 12,
+            70, 12,
+            70, 40,
+            12, 40,
+            12, 100,
+            -12, 100,
+            -12, 40,
+            -70, 40,
+            -70, 12,
+            -100, 12,
+        }
+    },
 
     -- Simple Clean Station Design
     visuals = {

--- a/content/world_objects/ore_furnace_station.lua
+++ b/content/world_objects/ore_furnace_station.lua
@@ -17,6 +17,33 @@ return {
         stone_cracking = true,
     },
 
+    collidable = {
+        shape = "polygon",
+        friendly = true,
+        vertices = {
+            18, -132,
+            -18, -132,
+            -18, -82,
+            -82, -82,
+            -82, -30,
+            -132, -30,
+            -132, 30,
+            -82, 30,
+            -82, 82,
+            -18, 82,
+            -18, 132,
+            18, 132,
+            18, 82,
+            82, 82,
+            82, 30,
+            132, 30,
+            132, -30,
+            82, -30,
+            82, -82,
+            18, -82,
+        }
+    },
+
     description = "A sprawling refinery that superheats ore shipments into refined alloys.",
 
     visuals = {

--- a/src/systems/collision/entity_collision.lua
+++ b/src/systems/collision/entity_collision.lua
@@ -276,13 +276,13 @@ function EntityCollision.handleEntityCollisions(collisionSystem, entity, world, 
                 goto continue
             end
 
-            -- Ignore collisions between the player and warp gates or stations (purely non-blocking)
+            -- Ignore collisions between the player and warp gates (stations now have physical hulls)
             do
                 local eIsPlayer = entity.isPlayer or (entity.components and entity.components.player)
                 local oIsPlayer = other.isPlayer or (other.components and other.components.player)
-                local eIsStructure = (entity.tag == "warp_gate" or entity.tag == "station")
-                local oIsStructure = (other.tag == "warp_gate" or other.tag == "station")
-                if (eIsPlayer and oIsStructure) or (oIsPlayer and eIsStructure) then
+                local eIsWarpGate = entity.tag == "warp_gate"
+                local oIsWarpGate = other.tag == "warp_gate"
+                if (eIsPlayer and oIsWarpGate) or (oIsPlayer and eIsWarpGate) then
                     goto continue
                 end
             end

--- a/src/systems/collision/station_shields.lua
+++ b/src/systems/collision/station_shields.lua
@@ -6,6 +6,10 @@ function StationShields.isStation(e)
   return (e and (e.tag == 'station' or (e.components and e.components.station))) or false
 end
 
+local function hasPhysicalHull(e)
+  return e and e.components and e.components.collidable ~= nil
+end
+
 function StationShields.isFriendly(e)
   if not e then return false end
   if e.isPlayer or (e.components and e.components.player) then return true end
@@ -15,8 +19,8 @@ function StationShields.isFriendly(e)
 end
 
 function StationShields.shouldIgnoreEntityCollision(a, b)
-  if StationShields.isStation(a) and StationShields.isFriendly(b) then return true end
-  if StationShields.isStation(b) and StationShields.isFriendly(a) then return true end
+  if StationShields.isStation(a) and not hasPhysicalHull(a) and StationShields.isFriendly(b) then return true end
+  if StationShields.isStation(b) and not hasPhysicalHull(b) and StationShields.isFriendly(a) then return true end
   return false
 end
 


### PR DESCRIPTION
## Summary
- add polygon-based colliders to each station definition so their silhouettes block movement
- teach the station template to construct scaled colliders and keep safe-zone radii in sync
- update collision checks so stations interact physically while preserving warp gate passthrough rules

## Testing
- `luac -p content/world_objects/beacon_station.lua content/world_objects/hub_station.lua content/world_objects/ore_furnace_station.lua src/templates/station.lua src/systems/collision/entity_collision.lua src/systems/collision/station_shields.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68de86f2610c8322a8f1e66708dd4e41

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add polygon colliders to stations and update station template and collision rules so stations physically block movement while warp gates remain pass-through.
> 
> - **Stations**:
>   - Add `collidable` polygon hulls (marked `friendly`) to `content/world_objects/beacon_station.lua`, `hub_station.lua`, and `ore_furnace_station.lua`.
> - **Collision**:
>   - Player passthrough now limited to `warp_gate` only; stations collide physically.
>   - Update `StationShields.shouldIgnoreEntityCollision` to ignore friendlies only for stations without `collidable`; add `hasPhysicalHull`.
> - **Station Template**:
>   - Construct `components.collidable` from config; scale `vertices`/`radius` by visuals size and set entity `radius`.
>   - Auto-derive `weapon_disable_radius` and `shield_radius` from hull size when not explicitly set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50aeef563ce7fa72d62ce31f0558afa85648447. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->