### PR TITLE
Route asteroid geometry logging through debug system

### DIFF
--- a/src/core/util.lua
+++ b/src/core/util.lua
@@ -1,3 +1,5 @@
+local Log = require("src.core.log")
+
 local util = {}
 
 function util.clamp(x, a, b)
@@ -88,7 +90,7 @@ function util.generateAsteroidGeometry(radius, opts)
     local x = r * math.cos(angle)
     local y = r * math.sin(angle)
     table.insert(vertices, {x, y})
-    print("  Vertex " .. (i+1) .. ": (" .. x .. "," .. y .. ")")
+    Log.debug("development", "Asteroid vertex %d: (%.3f, %.3f)", i + 1, x, y)
   end
 
   local chunkCountRange = opts.chunkCount or {1, 3}


### PR DESCRIPTION
## Summary
- replace the asteroid geometry vertex print statement with a debug log routed through the existing logging system

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de892b422c8322b26eff9386446c83