### PR TITLE
Ensure Missile Launcher Homes On Nearest Target

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -97,6 +97,8 @@ local function spawn_projectile(x, y, angle, friendly, opts)
         length = opts.length,
         -- Lifetime override (useful for beam pulses)
         timed_life = opts.timed_life,
+        -- Attach runtime projectile effects (e.g., homing guidance)
+        additionalEffects = opts.additionalEffects,
     }
     -- Tag the projectile's source so collision can ignore self-hit
     extra_config.source = opts.source

--- a/src/templates/projectile.lua
+++ b/src/templates/projectile.lua
@@ -125,6 +125,7 @@ function Projectile.new(x, y, angle, friendly, config)
     end
 
     effectManager:loadConfig(config.effects or {})
+    effectManager:loadConfig(config.additionalEffects or {})
 
     dispatcher:emit(ProjectileEvents.SPAWN, {
         projectile = self,

--- a/src/templates/projectile_system/effects/homing.lua
+++ b/src/templates/projectile_system/effects/homing.lua
@@ -1,0 +1,185 @@
+local EffectRegistry = require("src.templates.projectile_system.effect_registry")
+local Events = require("src.templates.projectile_system.event_dispatcher").EVENTS
+local BeamWeapons = require("src.systems.turret.beam_weapons")
+
+local function clamp(value, minValue, maxValue)
+    if value < minValue then return minValue end
+    if value > maxValue then return maxValue end
+    return value
+end
+
+local function isTargetValid(target, projectile)
+    if not target or target.dead or not target.components or not target.components.position then
+        return false
+    end
+
+    local bulletComponent = projectile.components and projectile.components.bullet
+    local source = bulletComponent and bulletComponent.source
+    return BeamWeapons.isEnemyTarget(target, source)
+end
+
+local function findNearestTarget(projectile, world, maxRangeSq)
+    if not world or not world.get_entities_with_components then
+        return nil
+    end
+
+    local pos = projectile.components and projectile.components.position
+    if not pos then
+        return nil
+    end
+
+    local bulletComponent = projectile.components and projectile.components.bullet
+    local source = bulletComponent and bulletComponent.source
+
+    local nearest
+    local nearestDistSq = math.huge
+    local entities = world:get_entities_with_components("position")
+
+    for _, entity in ipairs(entities) do
+        if entity ~= source and not entity.dead and entity.components and entity.components.position then
+            if BeamWeapons.isEnemyTarget(entity, source) then
+                local epos = entity.components.position
+                local dx = epos.x - pos.x
+                local dy = epos.y - pos.y
+                local distSq = dx * dx + dy * dy
+                if (not maxRangeSq or distSq <= maxRangeSq) and distSq < nearestDistSq then
+                    nearest = entity
+                    nearestDistSq = distSq
+                end
+            end
+        end
+    end
+
+    if nearest and not isTargetValid(nearest, projectile) then
+        return nil
+    end
+
+    return nearest
+end
+
+local function factory(context, config)
+    local projectile = context.projectile
+    local world = config.world
+    local turnRate = config.turnRate or math.rad(270)
+    local reacquireDelay = config.reacquireDelay or 0.1
+    if reacquireDelay < 0 then
+        reacquireDelay = 0
+    end
+    local desiredSpeed = config.speed
+    local maintainNearest = config.retargetNearest ~= false
+
+    local maxRangeSq = nil
+    if config.maxRange and config.maxRange > 0 then
+        maxRangeSq = config.maxRange * config.maxRange
+    end
+
+    local currentTarget = config.target
+    local reacquireTimer = 0
+
+    local function acquire(forceNearest)
+        if not world or not world.get_entities_with_components then
+            if not isTargetValid(currentTarget, projectile) then
+                currentTarget = nil
+            end
+            return
+        end
+
+        if forceNearest then
+            local nearest = findNearestTarget(projectile, world, maxRangeSq)
+            if nearest then
+                currentTarget = nearest
+            end
+        else
+            if not isTargetValid(currentTarget, projectile) then
+                currentTarget = findNearestTarget(projectile, world, maxRangeSq)
+            elseif maintainNearest then
+                local nearest = findNearestTarget(projectile, world, maxRangeSq)
+                if nearest and nearest ~= currentTarget then
+                    currentTarget = nearest
+                end
+            end
+        end
+
+        if currentTarget and not isTargetValid(currentTarget, projectile) then
+            currentTarget = nil
+        end
+    end
+
+    local function steer(dt)
+        if not currentTarget or not isTargetValid(currentTarget, projectile) then
+            return
+        end
+
+        local position = projectile.components and projectile.components.position
+        local velocity = projectile.components and projectile.components.velocity
+        if not position or not velocity then
+            return
+        end
+
+        local targetPos = currentTarget.components.position
+        if not targetPos then
+            return
+        end
+
+        local desiredAngle = math.atan2(targetPos.y - position.y, targetPos.x - position.x)
+        local currentAngle = math.atan2(velocity.y or 0, velocity.x or 0)
+        local maxTurn = turnRate * dt
+        local diff = math.atan2(math.sin(desiredAngle - currentAngle), math.cos(desiredAngle - currentAngle))
+        local clamped = clamp(diff, -maxTurn, maxTurn)
+        local newAngle = currentAngle + clamped
+
+        local speed = math.sqrt((velocity.x or 0) * (velocity.x or 0) + (velocity.y or 0) * (velocity.y or 0))
+        if desiredSpeed and desiredSpeed > 0 then
+            speed = desiredSpeed
+        elseif speed <= 0 then
+            speed = 1
+        end
+
+        velocity.x = math.cos(newAngle) * speed
+        velocity.y = math.sin(newAngle) * speed
+        position.angle = newAngle
+    end
+
+    local events = {}
+
+    events[Events.SPAWN] = function()
+        reacquireTimer = reacquireDelay
+        if not isTargetValid(currentTarget, projectile) then
+            currentTarget = nil
+        end
+        acquire(true)
+    end
+
+    events[Events.UPDATE] = function(payload)
+        local dt = (payload and payload.dt) or 0
+        if dt < 0 then
+            dt = 0
+        end
+
+        reacquireTimer = reacquireTimer - dt
+        if reacquireTimer <= 0 then
+            reacquireTimer = reacquireDelay
+            acquire(true)
+        else
+            acquire(false)
+        end
+
+        steer(math.max(dt, 0.0001))
+    end
+
+    events[Events.HIT] = function()
+        currentTarget = nil
+    end
+
+    events[Events.EXPIRE] = function()
+        currentTarget = nil
+    end
+
+    return {
+        events = events,
+    }
+end
+
+EffectRegistry.register("homing", factory)
+
+return true

--- a/src/templates/projectile_system/effects/init.lua
+++ b/src/templates/projectile_system/effects/init.lua
@@ -1,4 +1,5 @@
 require("src.templates.projectile_system.effects.trail")
 require("src.templates.projectile_system.effects.explosion")
+require("src.templates.projectile_system.effects.homing")
 
 return true


### PR DESCRIPTION
## Summary
- add nearest-enemy acquisition for missile turrets and route spawned rockets through a homing effect
- extend projectile spawning to forward runtime effect definitions to the projectile template
- implement a reusable homing projectile effect that continually steers toward the closest valid target

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68deb5310bf88322ba62e9477f0d0191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Missile turrets now auto-acquire the nearest enemy and spawn missiles with a new homing effect, with the engine forwarding runtime projectile effects.
> 
> - **Turret Weapons**:
>   - **Missiles**: Auto-acquire nearest enemy target and set `lockOnTarget/lockOnProgress`; spawn missiles with `additionalEffects` homing guidance.
> - **Projectile System**:
>   - **New Effect**: Implement and register `effects/homing` (target reacquisition, steering, range checks).
>   - **Template**: `projectile.lua` loads `config.additionalEffects` via `effectManager:loadConfig(...)`.
> - **Game/World Integration**:
>   - `world.spawn_projectile` forwards `opts.additionalEffects` to projectile config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e5b54bf07bce76ba5723ab98498d0ff5ac78d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->