### PR TITLE
Add Reward Crate Open Interaction

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -107,7 +107,6 @@ local function spawn_projectile(x, y, angle, friendly, opts)
     end
 end
 
-
 --[[
     Game.load
 


### PR DESCRIPTION
## Summary
- replace the reward crate helper with an Open button that consumes a nearby crate directly when you have a Reward Key
- show the Reward Key requirement underneath the prompt with its icon and current/required counts
- restore the docking hotkey to only handle docking so it no longer auto-collects reward crates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68deb507e550832293e9cc794ae755a4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an in-world "Open" button for nearby reward crates that checks for a Reward Key and consumes the crate, plus pickup utilities to find nearest crate and streamline notifications.
> 
> - **UI (`src/core/ui.lua`)**:
>   - **Reward Crate Prompt**: Draws an in-world `Open` button for nearby `reward_crate` pickups; shows required `reward_crate_key` with icon and current/required counts; colors reflect availability.
>   - **Interaction Handling**: Mouse click on prompt verifies key, notifies if missing, collects the pickup, and triggers `Inventory.useItem("reward_crate")`.
> - **Systems (`src/systems/pickups.lua`)**:
>   - **Helpers**: Add `findNearestPickup(world, player, itemId, maxDistance)`, `collectPickup(player, pickup)`, and lightweight notification helpers for single results.
>   - **Content Lookup**: Resolve item names via `Content.getItem` for cleaner loot labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb214809fbecb7c46031301b1b06dcad42c14001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->