### PR TITLE
Fix Theme Monospace Font Initialization

### DIFF
--- a/src/core/theme.lua
+++ b/src/core/theme.lua
@@ -98,7 +98,7 @@ Theme.fonts = {
   small = love.graphics.newFont(12),
   xsmall = love.graphics.newFont(10),
   title = love.graphics.newFont(20),
-  monospace = love.graphics.newFont(12, "mono"),
+  monospace = love.graphics.newFont("assets/fonts/PressStart2P-Regular.ttf", 12),
 }
 
 function Theme.loadFonts()


### PR DESCRIPTION
## Summary
- replace the invalid monospace font initialization with a valid font asset so the theme module loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dee09f11e48322aba698941249d2fe