### PR TITLE
Fix Debug Panel Text Input Routing

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -227,10 +227,10 @@ end
 
 function love.textinput(text)
   -- Let debug panel handle text input first
-  if DebugPanel.textinput and DebugPanel.textinput() then
+  if DebugPanel.textinput and DebugPanel.textinput(text) then
     return
   end
-  
+
   -- Pass to input module
   if Input.love_textinput then
     Input.love_textinput(text)


### PR DESCRIPTION
## Summary
- forward the text payload into the debug panel textinput handler before falling back to the input module

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68dee09f11e48322aba698941249d2fe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass the `text` argument into `DebugPanel.textinput` in `love.textinput` so the debug panel can consume text before delegating to `Input`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9ecc87be90412dfbdb5ee0719be3d5490a3928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->