### PR TITLE
Fix debug logging compatibility

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -227,10 +227,10 @@ end
 
 function love.textinput(text)
   -- Let debug panel handle text input first
-  if DebugPanel.textinput and DebugPanel.textinput() then
+  if DebugPanel.textinput and DebugPanel.textinput(text) then
     return
   end
-  
+
   -- Pass to input module
   if Input.love_textinput then
     Input.love_textinput(text)

--- a/src/ui/debug_panel.lua
+++ b/src/ui/debug_panel.lua
@@ -123,7 +123,11 @@ function DebugPanel.keypressed(key)
 end
 
 -- Empty textinput handler (needed to prevent input from reaching the game)
-function DebugPanel.textinput()
+function DebugPanel.textinput(text)
+    -- Currently we don't consume any text input, but returning false ensures
+    -- other systems can continue receiving characters. The "text" parameter is
+    -- accepted to match Love2D's callback signature and to allow future
+    -- extensions.
     return false
 end
 


### PR DESCRIPTION
## Summary
- update the logging helper to accept both traditional debug flags and simple message strings
- forward LÖVE's textinput parameter through the debug panel so consumers can inspect typed characters

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dee09f11e48322aba698941249d2fe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors logging to accept either debug flags or message strings with improved whitelist handling, and forwards Love2D text input to the debug panel.
> 
> - **Core Logging (`src/core/log.lua`)**:
>   - `Log.debug` now accepts either a `flag` or a message string; routes to `Debug.debug` when a valid flag is provided, otherwise prints via `out`.
>   - Applies whitelist filtering based on the first string argument; ignores non-matching/non-string calls.
>   - Adds vararg helpers `tablePack`/`tableUnpack` and utilities for argument inspection.
> - **UI/Input**:
>   - `love.textinput` now forwards `text` to `DebugPanel.textinput(text)` in `main.lua`.
>   - `DebugPanel.textinput` signature updated to accept `text` in `src/ui/debug_panel.lua`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9d29601275619637f24b93a0c927c7e85945d5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->