### PR TITLE
Reset Game State On Menu Exit

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -49,14 +49,28 @@ end
 
 love = love or {}
 function love.setScreen(newScreen)
+    local previousScreen = screen
+    if previousScreen == newScreen then
+        return
+    end
+
     screen = newScreen
 
     if newScreen == "start" then
+        if previousScreen == "game" and Game and Game.unload then
+            Game.unload()
+        end
         startScreen = Start.new()
         love.mouse.setVisible(true)
+        if love.mouse and love.mouse.setRelativeMode then
+            love.mouse.setRelativeMode(false)
+        end
         Sound.playMusic("adrift")
-    elseif newScreen == "game" and not UIManager then
-        UIManager = require("src.core.ui_manager")
+        UIManager = nil
+    elseif newScreen == "game" then
+        if not UIManager then
+            UIManager = require("src.core.ui_manager")
+        end
     end
 
     configureInput()

--- a/src/core/ui_manager.lua
+++ b/src/core/ui_manager.lua
@@ -41,24 +41,38 @@ local Log = require("src.core.log")
 
 local UIManager = {}
 
+local DEFAULT_Z_INDEX = {
+  inventory = 10,
+  ship = 15,
+  bounty = 20,
+  skills = 30,
+  docked = 40,
+  map = 50,
+  warp = 60,
+  escape = 100,
+  settings = 110,
+  rewardWheel = 115,
+  debug = 120,
+}
+
 -- Create warp instance
 local warpInstance = Warp:new()
 
 -- Central UI state
 UIManager.state = {
-  inventory = { open = false, zIndex = 10 },
-  ship = { open = false, zIndex = 15 },
-  bounty = { open = false, zIndex = 20 },
-  skills = { open = false, zIndex = 30 },
-  docked = { open = false, zIndex = 40 },
-  map = { open = false, zIndex = 50 },
-  warp = { open = false, zIndex = 60 },
-  escape = { open = false, zIndex = 100, showingSaveSlots = false }, -- Escape menu should be on top
-  settings = { open = false, zIndex = 110 }, -- Settings panel should be on top of escape
-  rewardWheel = { open = false, zIndex = 115 }, -- Reward wheel panel
-  debug = { open = false, zIndex = 120 } -- Debug panel should be on top of everything
+  inventory = { open = false, zIndex = DEFAULT_Z_INDEX.inventory },
+  ship = { open = false, zIndex = DEFAULT_Z_INDEX.ship },
+  bounty = { open = false, zIndex = DEFAULT_Z_INDEX.bounty },
+  skills = { open = false, zIndex = DEFAULT_Z_INDEX.skills },
+  docked = { open = false, zIndex = DEFAULT_Z_INDEX.docked },
+  map = { open = false, zIndex = DEFAULT_Z_INDEX.map },
+  warp = { open = false, zIndex = DEFAULT_Z_INDEX.warp },
+  escape = { open = false, zIndex = DEFAULT_Z_INDEX.escape, showingSaveSlots = false }, -- Escape menu should be on top
+  settings = { open = false, zIndex = DEFAULT_Z_INDEX.settings }, -- Settings panel should be on top of escape
+  rewardWheel = { open = false, zIndex = DEFAULT_Z_INDEX.rewardWheel }, -- Reward wheel panel
+  debug = { open = false, zIndex = DEFAULT_Z_INDEX.debug } -- Debug panel should be on top of everything
 }
-UIManager.topZ = 120
+UIManager.topZ = DEFAULT_Z_INDEX.debug
 
 -- UI priorities for proper layering
 UIManager.layerOrder = {
@@ -717,11 +731,29 @@ function UIManager.closeAll(except)
   for _, comp in ipairs(except) do
     exceptSet[comp] = true
   end
-  
+
   for component, _ in pairs(UIManager.state) do
     if not exceptSet[component] then
       UIManager.close(component)
     end
+  end
+end
+
+function UIManager.reset()
+  UIManager.closeAll()
+  UIManager.modalActive = false
+  UIManager.modalComponent = nil
+  UIManager.topZ = DEFAULT_Z_INDEX.debug
+  for component, defaultZ in pairs(DEFAULT_Z_INDEX) do
+    if UIManager.state[component] then
+      UIManager.state[component].zIndex = defaultZ
+      if UIManager.state[component].open then
+        UIManager.state[component].open = false
+      end
+    end
+  end
+  if UIManager.state.escape then
+    UIManager.state.escape.showingSaveSlots = false
   end
 end
 

--- a/src/game.lua
+++ b/src/game.lua
@@ -543,6 +543,38 @@ function Game.load(fromSave, saveSlot, loadingScreen)
   return true
 end
 
+function Game.unload()
+  if UIManager and UIManager.reset then
+    UIManager.reset()
+  end
+
+  Events.clear()
+
+  if StateManager and StateManager.reset then
+    StateManager.reset()
+  end
+
+  if HotbarSystem and HotbarSystem.reset then
+    HotbarSystem.reset()
+  end
+
+  PlayerRef.set(nil)
+
+  Input.init({})
+
+  world = nil
+  Game.world = nil
+  camera = nil
+  player = nil
+  hub = nil
+  clickMarkers = {}
+  bounty = { uncollected = 0, entries = {} }
+  hoveredEntity = nil
+  hoveredEntityType = nil
+  collisionSystem = nil
+  refreshDockingState = nil
+end
+
 function Game.update(dt)
     Input.update(dt)
     UIManager.update(dt, player)

--- a/src/managers/state_manager.lua
+++ b/src/managers/state_manager.lua
@@ -242,7 +242,8 @@ end
 function StateManager.init(player, world)
   currentPlayer = player
   currentWorld = world
-  
+  autoSaveTimer = 0
+
   -- Ensure save directory exists
   if not love.filesystem.getInfo(SAVE_DIRECTORY) then
     Log.info("StateManager: Creating save directory at '" .. SAVE_DIRECTORY .. "'")
@@ -257,6 +258,12 @@ function StateManager.init(player, world)
   end
   
   Log.debug("State Manager initialized")
+end
+
+function StateManager.reset()
+  currentPlayer = nil
+  currentWorld = nil
+  autoSaveTimer = 0
 end
 
 -- Get current game state for saving

--- a/src/systems/hotbar.lua
+++ b/src/systems/hotbar.lua
@@ -70,6 +70,13 @@ function Hotbar.draw()
     -- The drawing logic will be in src/ui/hud/hotbar.lua
 end
 
+function Hotbar.reset()
+    Hotbar.slots = nil
+    Hotbar.state.active = {
+        turret_slots = {},
+    }
+end
+
 -- Populate hotbar from player's equipped turrets in the grid
 function Hotbar.populateFromPlayer(player, newModuleId, slotNum)
     if not player or not player.components or not player.components.equipment or not player.components.equipment.grid then

--- a/src/systems/spawning.lua
+++ b/src/systems/spawning.lua
@@ -496,6 +496,9 @@ local function spawnInitialEntities(player, hub, world)
   end
 
 function SpawningSystem.init(player, hub, world)
+  enemySpawnTimer = 0
+  bossSpawnTimer = 0
+  asteroidSpawnTimer = 0
   spawnInitialEntities(player, hub, world)
 end
 


### PR DESCRIPTION
## Summary
- clean up the active session when returning to the start screen so new games start from a blank slate
- add module-level reset hooks for the UI manager, state manager, hotbar, and spawning systems to avoid cross-session state

## Testing
- luac -p main.lua *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68df549910948322bce4aef4ac1c689b