### PR TITLE
Fix UI sound volume handling

### DIFF
--- a/src/ui/common/utils.lua
+++ b/src/ui/common/utils.lua
@@ -25,7 +25,6 @@ end
 
 -- UI Caching system for expensive calculations
 local textMetricsCache = {}
-local layoutCache = {}
 local cacheCounter = 0
 
 -- Cache text metrics (width/height) to avoid repeated font:getWidth/getHeight calls
@@ -67,33 +66,6 @@ function UIUtils.getCachedTextMetrics(text, font)
     end
 
     return cached
-end
-
--- Cache layout calculations (positioning, dimensions)
-function UIUtils.getCachedLayout(key, calculator)
-    local cached = layoutCache[key]
-    if not cached then
-        cached = calculator()
-        layoutCache[key] = cached
-    end
-    return cached
-end
-
--- Clear layout cache when resolution changes
-function UIUtils.clearLayoutCache()
-    layoutCache = {}
-end
-
--- Helper function for batching UI updates
-local updateCounters = {}
-function UIUtils.shouldUpdate(name, frequency)
-    frequency = frequency or 1 -- Update every frame by default
-    if not updateCounters[name] then
-        updateCounters[name] = 0
-    end
-
-    updateCounters[name] = updateCounters[name] + 1
-    return (updateCounters[name] % frequency) == 0
 end
 
 -- Check if point is in rectangle

--- a/src/ui/sounds.lua
+++ b/src/ui/sounds.lua
@@ -22,14 +22,14 @@ end
 -- Play a UI sound with optional volume scale (0.0 to 1.0)
 function UISounds.play(soundName, volumeScale)
     if not soundName then return end
-    
-    -- Get the audio settings
-    local audioSettings = Settings.getAudioSettings()
-    if not audioSettings.ui_sounds_enabled then return end
-    
+
+    -- Get the audio settings with sensible fallbacks
+    local audioSettings = Settings.getAudioSettings() or {}
+    if audioSettings.ui_sounds_enabled == false then return end
+
     -- Play the sound with proper volume scaling
     local volume = (audioSettings.ui_sounds_volume or 1.0) * (volumeScale or 1.0)
-    Sound.playSFX(soundName, nil, volume, nil, nil, nil, "ui")
+    Sound.playSFX(soundName, volume)
 end
 
 -- Shortcut for button click sound


### PR DESCRIPTION
## Summary
- ensure UI sounds honor audio settings defaults and play at the requested volume
- remove unused UI utility helpers that were no longer referenced

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68df5617ee548322a42ad05e841c53dc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure UI sounds respect settings defaults and volume scaling, and remove unused UI layout caching/update helpers.
> 
> - **Audio/Sounds (`src/ui/sounds.lua`)**:
>   - Use `Settings.getAudioSettings() or {}` with safe defaults; skip play only when `ui_sounds_enabled == false`.
>   - Simplify `Sound.playSFX` call to `(soundName, volume)`; compute volume via `(ui_sounds_volume or 1.0) * (volumeScale or 1.0)`.
> - **UI Utils (`src/ui/common/utils.lua`)**:
>   - Remove layout caching (`layoutCache`, `getCachedLayout`, `clearLayoutCache`).
>   - Remove batched update helper (`shouldUpdate`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3721ff2ebfd6e50e1a420b6bb3471271af35dd18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->