### PR TITLE
Remove unused UI utilities

### DIFF
--- a/src/ui/common/utils.lua
+++ b/src/ui/common/utils.lua
@@ -25,7 +25,6 @@ end
 
 -- UI Caching system for expensive calculations
 local textMetricsCache = {}
-local layoutCache = {}
 local cacheCounter = 0
 
 -- Cache text metrics (width/height) to avoid repeated font:getWidth/getHeight calls
@@ -67,33 +66,6 @@ function UIUtils.getCachedTextMetrics(text, font)
     end
 
     return cached
-end
-
--- Cache layout calculations (positioning, dimensions)
-function UIUtils.getCachedLayout(key, calculator)
-    local cached = layoutCache[key]
-    if not cached then
-        cached = calculator()
-        layoutCache[key] = cached
-    end
-    return cached
-end
-
--- Clear layout cache when resolution changes
-function UIUtils.clearLayoutCache()
-    layoutCache = {}
-end
-
--- Helper function for batching UI updates
-local updateCounters = {}
-function UIUtils.shouldUpdate(name, frequency)
-    frequency = frequency or 1 -- Update every frame by default
-    if not updateCounters[name] then
-        updateCounters[name] = 0
-    end
-
-    updateCounters[name] = updateCounters[name] + 1
-    return (updateCounters[name] % frequency) == 0
 end
 
 -- Check if point is in rectangle

--- a/src/ui/settings_panel.lua
+++ b/src/ui/settings_panel.lua
@@ -1,8 +1,6 @@
 local Theme = require("src.core.theme")
 local Viewport = require("src.core.viewport")
 local Settings = require("src.core.settings")
-local IconRenderer = require("src.content.icon_renderer")
-local AuroraTitle = require("src.shaders.aurora_title")
 local Notifications = require("src.ui.notifications")
 local Window = require("src.ui.common.window")
 local Dropdown = require("src.ui.common.dropdown")
@@ -27,7 +25,6 @@ local draggingSlider = nil
 local vsyncTypes = {Strings.getUI("off"), Strings.getUI("on")}
 local fpsLimitTypes = {Strings.getUI("unlimited"), "30", "60", "120", "144", "240"}
 -- Reticle color picker state (always visible sliders in popup)
-local colorPickerOpen = true
 local reticleGalleryOpen = false
 local scrollY = 0
 local scrollDragOffset = 0
@@ -144,28 +141,6 @@ local hoveredSlider = {
     sfx_volume = false,
     music_volume = false
 }
-
--- Helper function to truncate text with ellipsis if it doesn't fit
-local function truncateText(text, maxWidth, font)
-    local textWidth = font:getWidth(text)
-    if textWidth <= maxWidth then
-        return text
-    end
-
-    local ellipsis = "..."
-    local ellipsisWidth = font:getWidth(ellipsis)
-
-    if ellipsisWidth >= maxWidth then
-        return ""
-    end
-
-    local truncated = text
-    while font:getWidth(truncated .. ellipsis) > maxWidth and #truncated > 0 do
-        truncated = truncated:sub(1, -2)
-    end
-
-    return truncated .. ellipsis
-end
 
 function SettingsPanel.calculateContentHeight()
     -- If window/content bounds are available, compute contentHeight relative


### PR DESCRIPTION
## Summary
- remove unused dependencies and redundant state from the settings panel
- drop unused layout caching helpers that were no longer referenced

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68df5617ee548322a42ad05e841c53dc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused layout caching/batching helpers in `UIUtils` and drops unused imports/state and the `truncateText` helper from `settings_panel`.
> 
> - **UI Utilities (`src/ui/common/utils.lua`)**:
>   - Remove layout cache: delete `layoutCache`, `UIUtils.getCachedLayout`, and `UIUtils.clearLayoutCache`.
>   - Remove batching helper: delete `updateCounters` and `UIUtils.shouldUpdate`.
> - **Settings Panel (`src/ui/settings_panel.lua`)**:
>   - Remove unused requires: `IconRenderer`, `AuroraTitle`.
>   - Remove unused state: `colorPickerOpen`.
>   - Remove unused helper: `truncateText`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63b67e899c5756eec4e0a2aa7b6706ec149b1d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->