### PR TITLE
Prevent Canvas Leak During Draw Errors

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -182,19 +182,31 @@ end
 
 function love.draw()
   local drawStart = love.timer.getTime()
-  
-  Viewport.begin()
-  love.graphics.setFont(require("src.core.theme").fonts.normal)
-  if screen == "start" then
-    startScreen:draw()
-  else
-    Game.draw()
+  local viewportActive = false
+
+  local ok, err = xpcall(function()
+    Viewport.begin()
+    viewportActive = true
+
+    love.graphics.setFont(require("src.core.theme").fonts.normal)
+    if screen == "start" then
+      startScreen:draw()
+    else
+      Game.draw()
+    end
+  end, debug.traceback)
+
+  if viewportActive then
+    Viewport.finish()
   end
-  Viewport.finish()
-  
+
+  if not ok then
+    error(err)
+  end
+
   -- Draw loading screen on top of everything
   loadingScreen:draw()
-  
+
   -- Calculate and set draw time (in ms)
   local drawTime = (love.timer.getTime() - drawStart) * 1000
   DebugPanel.setRenderStats(drawTime)


### PR DESCRIPTION
## Summary
- wrap the main draw routine in xpcall so viewport cleanup runs even if drawing fails
- always finish the viewport before rethrowing errors to keep the backbuffer valid

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68df6f0963648322bde2be48a7acef20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the main draw routine in xpcall to safely finish the viewport on errors and rethrow with traceback.
> 
> - **Rendering (`main.lua`)**:
>   - Wrap `love.draw` rendering in `xpcall(debug.traceback)` to capture errors.
>   - Track `viewportActive` and call `Viewport.finish()` only if `Viewport.begin()` succeeded.
>   - Rethrow captured error after cleanup to preserve error reporting.
>   - No changes to render stats or loading overlay order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57d996580963cfc06cf7b7e46ac49d00a232c629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->