### PR TITLE
Refactor Player State Components

### DIFF
--- a/src/components/docking_status.lua
+++ b/src/components/docking_status.lua
@@ -1,0 +1,13 @@
+local DockingStatus = {}
+
+function DockingStatus.new(initial)
+  initial = initial or {}
+  return {
+    docked = initial.docked or false,
+    can_dock = initial.can_dock or false,
+    nearby_station = initial.nearby_station or nil,
+    docked_station = initial.docked_station or nil,
+  }
+end
+
+return DockingStatus

--- a/src/components/engine_effects.lua
+++ b/src/components/engine_effects.lua
@@ -13,8 +13,10 @@ function EngineEffects.new(player)
         local x = self.player.components.position.x
         local y = self.player.components.position.y
         local angle = self.player.components.position.angle -- Assuming physics component holds angle
-        local isThrusting = self.player.thrusterState.isThrusting
-        local intensity = self.player.thrusterState.forward + self.player.thrusterState.boost -- Or however intensity is calculated
+        local playerState = self.player.components and self.player.components.player_state
+        local thrusterState = playerState and playerState.thruster_state or {}
+        local isThrusting = thrusterState.isThrusting
+        local intensity = (thrusterState.forward or 0) + (thrusterState.boost or 0) -- Or however intensity is calculated
         
 
         self.engineTrail:update(dt, x, y, angle, isThrusting, intensity)

--- a/src/components/player_state.lua
+++ b/src/components/player_state.lua
@@ -1,0 +1,28 @@
+local PlayerState = {}
+
+function PlayerState.new(initial)
+  initial = initial or {}
+  return {
+    is_player = true,
+    move_target = initial.move_target or nil,
+    weapons_disabled = initial.weapons_disabled or false,
+    was_in_hub = initial.was_in_hub or false,
+    thruster_state = initial.thruster_state or {
+      forward = 0,
+      reverse = 0,
+      strafeLeft = 0,
+      strafeRight = 0,
+      boost = 0,
+      brake = 0,
+      isThrusting = false,
+    },
+    dash_cooldown = initial.dash_cooldown or 0,
+    shield_active = initial.shield_active or false,
+    target = initial.target or nil,
+    target_type = initial.target_type or "enemy",
+    can_warp = initial.can_warp or false,
+    was_in_warp_range = initial.was_in_warp_range or false,
+  }
+end
+
+return PlayerState

--- a/src/core/input.lua
+++ b/src/core/input.lua
@@ -500,7 +500,8 @@ function Input.mousereleased(x, y, button)
 
     if mainState.UIManager.isOpen("bounty") then
         local Bounty = require("src.ui.bounty")
-        local consumed, shouldClose = Bounty.mousereleased(x, y, button, gameState.player.docked, function()
+        local docking = gameState.player and gameState.player.components and gameState.player.components.docking_status
+        local consumed, shouldClose = Bounty.mousereleased(x, y, button, docking and docking.docked, function()
             gameState.player:addGC(gameState.bounty.uncollected or 0)
             gameState.bounty.uncollected = 0
         end)

--- a/src/managers/state_manager.lua
+++ b/src/managers/state_manager.lua
@@ -1,6 +1,7 @@
 local Events = require("src.core.events")
 local Log = require("src.core.log")
 local PortfolioManager = require("src.managers.portfolio")
+local PlayerHotbar = require("src.systems.player.hotbar")
 
 local StateManager = {}
 
@@ -176,9 +177,7 @@ local function restoreEquipment(player, equipmentState)
   if player.updateShieldHP then
     player:updateShieldHP()
   end
-  if player.updateHotbar then
-    player:updateHotbar()
-  end
+  PlayerHotbar.populate(player)
 end
 
 -- Get current player
@@ -422,7 +421,10 @@ local function applyGameState(state, player, world)
   if state.portfolio then
     PortfolioManager.init(state.portfolio)
   end
-  player.docked = playerData.docked or false
+  local docking = player.components and player.components.docking_status
+  if docking then
+    docking.docked = playerData.docked or false
+  end
   
   if currentPlayer.components and currentPlayer.components.progression and state.player.progression then
     currentPlayer.components.progression = require("src.components.progression").deserialize(state.player.progression)
@@ -486,7 +488,10 @@ local function createGameFromSave(state)
   player.active_quests = playerData.active_quests or {}
   player.quest_progress = playerData.quest_progress or {}
   player.quest_start_times = playerData.quest_start_times or {}
-  player.docked = playerData.docked or false
+  local docking = player.components and player.components.docking_status
+  if docking then
+    docking.docked = playerData.docked or false
+  end
 
   -- Set position
   if playerData.position then

--- a/src/systems/collision/station_shields.lua
+++ b/src/systems/collision/station_shields.lua
@@ -49,7 +49,9 @@ end
 function StationShields.checkStationSafeZone(bullet, target)
     local isPlayer = target.isPlayer or (target.components.player ~= nil)
     local isEnemyBullet = not ((bullet.components and bullet.components.collidable and bullet.components.collidable.friendly) or false)
-    return isPlayer and (target.weaponsDisabled or false) and isEnemyBullet
+    local playerState = target.components and target.components.player_state
+    local weaponsDisabled = playerState and playerState.weapons_disabled
+    return isPlayer and (weaponsDisabled or false) and isEnemyBullet
 end
 
 function StationShields.handleStationShieldCollision(entity1, entity2)

--- a/src/systems/engine_trail.lua
+++ b/src/systems/engine_trail.lua
@@ -18,8 +18,9 @@ function EngineTrailSystem.update(dt, world)
 		local pos = player.components.position
 		if trail and phys and pos then
 			-- Prefer player-controlled thruster state (set by PlayerSystem), fall back to physics body
-			local thrusterState = (player.thrusterState and type(player.thrusterState) == "table" and player.thrusterState)
-				or (phys.getThrusterState and phys:getThrusterState())
+                        local playerState = player.components and player.components.player_state
+                        local thrusterState = (playerState and playerState.thruster_state)
+                                or (phys.getThrusterState and phys:getThrusterState())
 				or { isThrusting = false }
 			-- Combine inputs into an overall intensity
 			local intensity = (thrusterState.forward or 0)

--- a/src/systems/input_intents.lua
+++ b/src/systems/input_intents.lua
@@ -40,7 +40,8 @@ function InputIntentsSystem.update(dt, player, uiManager)
   end
 
   local modalActive = uiManager and uiManager.isModalActive and uiManager.isModalActive() or false
-  local blocked = modalActive or player.docked or player.dead or player.frozen
+  local docking = player.components and player.components.docking_status
+  local blocked = modalActive or (docking and docking.docked) or player.dead or player.frozen
 
   if blocked then
     resetIntent(player, modalActive)

--- a/src/systems/player/docking.lua
+++ b/src/systems/player/docking.lua
@@ -1,0 +1,57 @@
+local Events = require("src.core.events")
+local DockedUI = require("src.ui.docked")
+local PlayerHotbar = require("src.systems.player.hotbar")
+
+local Docking = {}
+
+local function get_docking(player)
+  return player and player.components and player.components.docking_status
+end
+
+local function get_state(player)
+  return player and player.components and player.components.player_state
+end
+
+function Docking.dock(player, station)
+  local docking = get_docking(player)
+  if not docking then return end
+
+  docking.docked = true
+  docking.docked_station = station
+  docking.can_dock = false
+  docking.nearby_station = nil
+
+  local state = get_state(player)
+  if state then
+    state.move_target = nil
+  end
+
+  if player.components and player.components.physics and player.components.physics.body then
+    player.components.physics.body.vx = 0
+    player.components.physics.body.vy = 0
+  end
+
+  if player.components and player.components.health then
+    local h = player.components.health
+    h.shield = h.maxShield or h.shield
+  end
+
+  DockedUI.show(player, station)
+  PlayerHotbar.clearAssignments()
+  Events.emit(Events.GAME_EVENTS.PLAYER_DOCKED, { player = player, station = station })
+end
+
+function Docking.undock(player)
+  local docking = get_docking(player)
+  if not docking then return end
+
+  docking.docked = false
+  docking.docked_station = nil
+  docking.nearby_station = nil
+
+  DockedUI.hide()
+  PlayerHotbar.clearAssignments()
+  Events.emit(Events.GAME_EVENTS.PLAYER_UNDOCKED, { player = player })
+end
+
+return Docking

--- a/src/systems/player/hotbar.lua
+++ b/src/systems/player/hotbar.lua
@@ -1,0 +1,23 @@
+local Hotbar = require("src.systems.hotbar")
+
+local PlayerHotbar = {}
+
+local function ensure_state()
+  Hotbar.state = Hotbar.state or {}
+  Hotbar.state.active = Hotbar.state.active or {}
+  Hotbar.state.active.turret_slots = Hotbar.state.active.turret_slots or {}
+end
+
+function PlayerHotbar.populate(player, newModuleId, slotNum)
+  if not player then return end
+  if Hotbar.populateFromPlayer then
+    Hotbar.populateFromPlayer(player, newModuleId, slotNum)
+  end
+end
+
+function PlayerHotbar.clearAssignments()
+  ensure_state()
+  Hotbar.state.active.turret_slots = {}
+end
+
+return PlayerHotbar

--- a/src/systems/render/player_renderer.lua
+++ b/src/systems/render/player_renderer.lua
@@ -128,7 +128,9 @@ function PlayerRenderer.render(entity, playerRef)
     -- Engine trails are now handled by the engine_trail component in entity_renderers.lua
     
     -- Show full shield bubble when inside station area or when channeling shields
-    if entity.weaponsDisabled or entity.shieldChannel then
+    local playerState = entity.components and entity.components.player_state
+    local weaponsDisabled = (playerState and playerState.weapons_disabled) or entity.weaponsDisabled
+    if weaponsDisabled or entity.shieldChannel then
         ShieldEffects.drawShieldBubble(entity)
     end
     

--- a/src/systems/render/shield_effects.lua
+++ b/src/systems/render/shield_effects.lua
@@ -119,7 +119,9 @@ function ShieldEffects.drawShieldBubble(entity)
     -- Draw only on recent impact or special cases (channeling, disabled)
     local currentTime = love.timer.getTime()
     local hasRecentImpact = entity.shieldImpactTime and currentTime < entity.shieldImpactTime
-    local isSpecialCase = entity.shieldChannel or entity.weaponsDisabled
+    local playerState = entity.components and entity.components.player_state
+    local weaponsDisabled = (playerState and playerState.weapons_disabled) or entity.weaponsDisabled
+    local isSpecialCase = entity.shieldChannel or weaponsDisabled
     if not col then return end
     if not (hasRecentImpact or isSpecialCase) then return end
     

--- a/src/ui/docked.lua
+++ b/src/ui/docked.lua
@@ -17,6 +17,10 @@ local Dropdown = require("src.ui.common.dropdown")
 
 local DockedUI = {}
 
+local function get_docking(player)
+    return player and player.components and player.components.docking_status
+end
+
 local function computeWindowBounds()
     local sw, sh = Viewport.getDimensions()
     local width = math.floor(math.min(sw - 80, math.max(900, sw * 0.65)))
@@ -690,7 +694,8 @@ end
 
 -- Draw the docked window
 function DockedUI.draw(player)
-    if not DockedUI.visible or not player or not player.docked then return end
+    local docking = get_docking(player)
+    if not DockedUI.visible or not player or not (docking and docking.docked) then return end
     if not DockedUI.window then DockedUI.init() end
     DockedUI.window.visible = DockedUI.visible
     DockedUI.window:draw()

--- a/src/ui/hud/hotbar.lua
+++ b/src/ui/hud/hotbar.lua
@@ -368,7 +368,8 @@ function Hotbar.draw(player)
     end
 
     -- Draw red X overlay when weapons are disabled and slot has a turret
-    if player and player.weaponsDisabled and slot.item and type(slot.item) == 'string' and slot.item:match('^turret_slot_%d+$') then
+    local playerState = player and player.components and player.components.player_state
+    if playerState and playerState.weapons_disabled and slot.item and type(slot.item) == 'string' and slot.item:match('^turret_slot_%d+$') then
       drawRedX(rx, ry, size)
     end
 

--- a/src/ui/ship.lua
+++ b/src/ui/ship.lua
@@ -46,6 +46,10 @@ local HotbarSystem = require("src.systems.hotbar")
 local Notifications = require("src.ui.notifications")
 local HotbarUI = require("src.ui.hud.hotbar")
 
+local function get_docking(player)
+    return player and player.components and player.components.docking_status
+end
+
 local function resolveModuleDisplayName(entry)
     if not entry then return nil end
     local module = entry.module
@@ -444,8 +448,10 @@ function Ship:draw(player, x, y, w, h)
     local shipClass = player.class or (player.ship and player.ship.class) or "Unknown Class"
     love.graphics.print("Class: " .. shipClass, infoX, iconY + 22)
 
-    local statusColor = player.docked and Theme.colors.success or Theme.colors.warning
-    local statusText = player.docked and "DOCKED - Fitting Available" or "UNDOCKED - Fitting Locked"
+    local docking = get_docking(player)
+    local isDocked = docking and docking.docked
+    local statusColor = isDocked and Theme.colors.success or Theme.colors.warning
+    local statusText = isDocked and "DOCKED - Fitting Available" or "UNDOCKED - Fitting Locked"
     Theme.setColor(statusColor)
     love.graphics.print(statusText, infoX, iconY + 36)
 


### PR DESCRIPTION
## Summary
- add player_state and docking_status components so the player entity is only a component bag
- move player update and docking logic into the player system and new helper modules
- update game/UI code to reference the new components and fire docking events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e04adba02c8322b790738d756f03dd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds player_state and docking_status components, migrates docking/thruster/warp/weapons handling into systems, and updates UI/render/input/save flows to use the new components.
> 
> - **Core Components**:
>   - Add `src/components/player_state.lua` and `src/components/docking_status.lua` to hold player flags (thruster, warp, weapons) and docking state.
> - **Player/System Refactor**:
>   - `src/systems/player.lua`: reworked to read/write `components.player_state` and `components.docking_status`, manage thrusters/dash/warp/weapon-disable, and expose `dock/undock` via `PlayerSystem`.
>   - Extract docking into `src/systems/player/docking.lua` and hotbar helpers into `src/systems/player/hotbar.lua`.
>   - `src/entities/player.lua`: remove inline state/methods (dock/undock/updateHotbar), initialize new components, delegate hotbar to `PlayerHotbar`.
> - **Game/Event Wiring**:
>   - `src/game.lua`: emit/consume docking events using `components.docking_status`; call `PlayerSystem.dock/undock`; refresh docking proximity via component state.
>   - `src/systems/input_intents.lua`: block input when `docking_status.docked`.
> - **UI/Rendering**:
>   - `src/core/ui.lua`, `src/ui/docked.lua`, `src/ui/ship.lua`, `src/ui/hud/hotbar.lua`, `src/systems/render/player_renderer.lua`, `src/systems/render/shield_effects.lua`: switch checks from `player.docked/weaponsDisabled` to `components.docking_status` and `components.player_state.weapons_disabled`.
> - **Effects/Trails**:
>   - `src/components/engine_effects.lua`, `src/systems/engine_trail.lua`: read thruster data from `components.player_state.thruster_state`.
> - **Collision**:
>   - `src/systems/collision/station_shields.lua`: safe-zone logic uses `components.player_state.weapons_disabled`.
> - **Persistence**:
>   - `src/managers/state_manager.lua`: load/save uses `components.docking_status.docked` and repopulates hotbar via `PlayerHotbar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 650e9931c41800ac9b556442b0ffada63f2fd6d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->