### PR TITLE
Integrate Tiny ECS For Lifetime System

### DIFF
--- a/src/core/ecs.lua
+++ b/src/core/ecs.lua
@@ -1,0 +1,80 @@
+--[[
+    ECS Manager
+
+    Wraps the vendored tiny-ecs world and exposes a thin abstraction that keeps
+    system context wiring consistent with the previous manual pipeline. This
+    allows us to progressively move bespoke systems across without rewriting the
+    broader game loop all at once.
+]]
+
+local tiny = require("src.libs.tiny")
+
+local ECS = {}
+ECS.__index = ECS
+
+function ECS.new()
+    local self = setmetatable({}, ECS)
+    self.tiny_world = tiny.world()
+    self.context = {}
+    self.systems = {}
+    self.game_world = nil
+    return self
+end
+
+function ECS:setWorld(world)
+    self.game_world = world
+    if self.tiny_world then
+        self.tiny_world.game_world = world
+    end
+end
+
+local function sync_system_worlds(tiny_world, game_world)
+    if not tiny_world or not tiny_world.systems then return end
+    for _, system in ipairs(tiny_world.systems) do
+        system.game_world = game_world
+    end
+end
+
+function ECS:addSystem(system)
+    if not system then return end
+    table.insert(self.systems, system)
+    self.tiny_world:addSystem(system)
+    system.game_world = self.game_world
+    return system
+end
+
+function ECS:addEntity(entity)
+    if not self.tiny_world then return end
+    self.tiny_world:addEntity(entity)
+end
+
+function ECS:removeEntity(entity)
+    if not self.tiny_world then return end
+    self.tiny_world:removeEntity(entity)
+end
+
+function ECS:refresh(entity)
+    if not self.tiny_world then return end
+    self.tiny_world:refresh(entity)
+end
+
+local function merge_context(base, updates)
+    if not updates then return base end
+    for key, value in pairs(updates) do
+        base[key] = value
+    end
+    return base
+end
+
+function ECS:update(dt, context)
+    if not self.tiny_world then return end
+
+    self.context.dt = dt
+    self.context.world = self.game_world
+    merge_context(self.context, context)
+
+    sync_system_worlds(self.tiny_world, self.game_world)
+    self.tiny_world:update(dt, self.context)
+end
+
+return ECS

--- a/src/core/world.lua
+++ b/src/core/world.lua
@@ -72,6 +72,7 @@ function World.new(width, height)
   self.nebulaW, self.nebulaH = 0, 0
   self.nebulaCanvas = nil
   self.planets = {}
+  self.ecs_world = nil
   -- Initial stars build
   local sw, sh = Viewport.getDimensions()
   self.starW, self.starH = sw, sh
@@ -90,6 +91,14 @@ end
 -- Attach a quadtree implementation for accelerated spatial queries.
 function World:setQuadtree(quadtree)
     self.quadtree = quadtree
+end
+
+function World:setECSWorld(ecs_world)
+    self.ecs_world = ecs_world
+end
+
+function World:getECSWorld()
+    return self.ecs_world
 end
 
 -- A lightweight throttle for background animation work; avoids redundant math.
@@ -132,12 +141,18 @@ function World:addEntity(entity)
     self.next_id = self.next_id + 1
     entity.id = id
     self.entities[id] = entity
+    if self.ecs_world then
+        self.ecs_world:addEntity(entity)
+    end
     return entity
 end
 
 function World:removeEntity(entity)
     if entity and entity.id then
         self.entities[entity.id] = nil
+        if self.ecs_world then
+            self.ecs_world:removeEntity(entity)
+        end
     end
 end
 
@@ -186,6 +201,12 @@ function World:update(dt)
         if entity.dead then
             self:removeEntity(entity)
         end
+    end
+end
+
+function World:refreshEntity(entity)
+    if self.ecs_world then
+        self.ecs_world:refresh(entity)
     end
 end
 

--- a/src/game.lua
+++ b/src/game.lua
@@ -42,6 +42,7 @@ local LifetimeSystem = require("src.systems.lifetime")
 local EngineTrailSystem = require("src.systems.engine_trail")
 local WarpGateSystem = require("src.systems.warp_gate_system")
 local SystemPipeline = require("src.core.system_pipeline")
+local ECS = require("src.core.ecs")
 local StatusBars = require("src.ui.hud.status_bars")
 local SkillXpPopup = require("src.ui.hud.skill_xp_popup")
 local HotbarSystem = require("src.systems.hotbar")
@@ -72,6 +73,7 @@ local collisionSystem
 local refreshDockingState
 local systemPipeline
 local systemContext = {}
+local ecsManager
 
 -- Make world accessible
 Game.world = world
@@ -155,7 +157,9 @@ local function createSystemPipeline()
       PhysicsSystem.update(ctx.dt, ctx.world:getEntities())
     end,
     function(ctx)
-      LifetimeSystem.update(ctx.dt, ctx.world)
+      if ecsManager then
+        ecsManager:update(ctx.dt, ctx)
+      end
     end,
     function(ctx)
       BoundarySystem.update(ctx.world)
@@ -282,6 +286,10 @@ function Game.load(fromSave, saveSlot, loadingScreen)
   world.spawn_projectile = spawn_projectile
   -- Update the accessible world reference
   Game.world = world
+  ecsManager = ECS.new()
+  ecsManager:setWorld(world)
+  world:setECSWorld(ecsManager)
+  ecsManager:addSystem(LifetimeSystem.create())
   camera = Camera.new()
 
   -- Step 6: Create stations
@@ -715,8 +723,13 @@ function Game.unload()
 
   systemPipeline = nil
   systemContext = {}
+  ecsManager = nil
 
   Input.init({})
+
+  if world then
+    world:setECSWorld(nil)
+  end
 
   world = nil
   Game.world = nil

--- a/src/libs/tiny.lua
+++ b/src/libs/tiny.lua
@@ -1,0 +1,179 @@
+--[[
+    tiny-ecs inspired entity-component-system helpers.
+
+    This lightweight implementation vendors the tiny-ecs API surface that we
+    rely on for the project's first integration pass. It keeps the familiar
+    constructor helpers (world/process systems and component filters) so future
+    systems can transition toward full tiny-ecs usage without immediately
+    rewriting every subsystem.
+
+    The implementation focuses on clarity over micro-optimisation: we evaluate
+    filters on demand during updates which keeps entity/component bookkeeping
+    straightforward while we migrate off bespoke loops elsewhere in the code
+    base.
+]]
+
+local tiny = {}
+
+local function is_system_active(system)
+    if system == nil then return false end
+    if system.enabled == false then return false end
+    if system.active == false then return false end
+    return true
+end
+
+function tiny.system()
+    return { enabled = true }
+end
+
+function tiny.processingSystem()
+    local system = tiny.system()
+    system.__isProcessing = true
+    function system:process(_, _, _)
+        -- Intentionally left blank; concrete systems should override this.
+    end
+    return system
+end
+
+local function entity_has_components(entity, keys, require_any)
+    if not entity then return false end
+    local components = entity.components
+    if not components then return false end
+
+    if require_any then
+        for _, key in ipairs(keys) do
+            if components[key] then
+                return true
+            end
+        end
+        return #keys == 0
+    else
+        for _, key in ipairs(keys) do
+            if not components[key] then
+                return false
+            end
+        end
+        return true
+    end
+end
+
+function tiny.requireAll(...)
+    local keys = { ... }
+    return function(entity)
+        return entity_has_components(entity, keys, false)
+    end
+end
+
+function tiny.requireAny(...)
+    local keys = { ... }
+    return function(entity)
+        return entity_has_components(entity, keys, true)
+    end
+end
+
+function tiny.requireNone(...)
+    local keys = { ... }
+    return function(entity)
+        if not entity then return true end
+        local components = entity.components
+        if not components then return true end
+        for _, key in ipairs(keys) do
+            if components[key] then
+                return false
+            end
+        end
+        return true
+    end
+end
+
+local World = {}
+World.__index = World
+
+function World:addSystem(system)
+    if not system then return end
+    if system.world and system.world ~= self then
+        error("system already added to a different world", 2)
+    end
+    system.world = self
+    table.insert(self.systems, system)
+    if system.onAddToWorld then
+        system:onAddToWorld(self)
+    end
+    return system
+end
+
+function World:removeSystem(system)
+    if not system then return end
+    for index, candidate in ipairs(self.systems) do
+        if candidate == system then
+            table.remove(self.systems, index)
+            if system.onRemoveFromWorld then
+                system:onRemoveFromWorld(self)
+            end
+            system.world = nil
+            break
+        end
+    end
+end
+
+function World:addEntity(entity)
+    if not entity or self.entities[entity] then
+        return
+    end
+    self.entities[entity] = true
+    table.insert(self.entityList, entity)
+end
+
+function World:removeEntity(entity)
+    if not entity or not self.entities[entity] then
+        return
+    end
+    self.entities[entity] = nil
+    for index, candidate in ipairs(self.entityList) do
+        if candidate == entity then
+            table.remove(self.entityList, index)
+            break
+        end
+    end
+end
+
+function World:refresh(entity)
+    -- This lightweight adapter evaluates filters during update so there is no
+    -- cached membership data to refresh. The function exists to keep parity
+    -- with the tiny-ecs API and future-proof call sites that expect it.
+    return entity
+end
+
+function World:update(dt, context)
+    for _, system in ipairs(self.systems) do
+        if is_system_active(system) then
+            if system.__isProcessing then
+                local filter = system.filter
+                for _, entity in ipairs(self.entityList) do
+                    if entity and (not filter or filter(entity)) then
+                        system:process(entity, dt, context)
+                    end
+                end
+            elseif system.update then
+                system:update(dt, context)
+            end
+        end
+    end
+end
+
+function tiny.world(...)
+    local systems = { ... }
+    local world = setmetatable({
+        systems = {},
+        entities = {},
+        entityList = {},
+    }, World)
+
+    for _, system in ipairs(systems) do
+        world:addSystem(system)
+    end
+
+    return world
+end
+
+return tiny


### PR DESCRIPTION
## Summary
- vendor a tiny-ecs compatible helper and wrap it with a reusable ECS manager
- hook the world bootstrap/pipeline into the ECS manager so entities stay in sync
- port the lifetime system to a tiny-ecs processing system and remove the bespoke loop

## Testing
- Not run (Love2D runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e0bc81b7b08322b41b79ecc3286b44

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Vendors tiny-ecs, introduces an ECS manager, wires it into world/game, and ports LifetimeSystem to a tiny-ecs processing system.
> 
> - **Core ECS**:
>   - Add `src/libs/tiny.lua` lightweight tiny-ecs API (world, processing systems, component filters, add/remove entity/system, update loop).
>   - Add `src/core/ecs.lua` manager wrapping tiny world, syncing `game_world`, merging context, and proxying `addEntity`/`removeEntity`/`refresh`.
> - **World/Game Wiring**:
>   - `src/core/world.lua`: store `ecs_world`; propagate entity add/remove/refresh; helpers `setECSWorld`/`getECSWorld`.
>   - `src/game.lua`: instantiate `ECS` during load, bind to world, register `LifetimeSystem.create()`; replace direct lifetime update with `ecsManager:update`; clean up ECS on unload.
> - **Systems**:
>   - `src/systems/lifetime.lua`: refactor to tiny-ecs processing system via `create()` with `requireAny("timed_life", "max_range")`; move per-entity logic into `process` and reuse helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c64859b61a4455a7f8b8d60108bdab1238ab470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->