### PR TITLE
Gate Utility Beam Audio On Active Input

### DIFF
--- a/src/systems/turret/effects.lua
+++ b/src/systems/turret/effects.lua
@@ -31,7 +31,13 @@ function TurretEffects.playFiringSound(turret)
         turret.miningSoundInstance = Sound.triggerEvent('weapon_mining_laser', x, y)
         Log.debug("Started mining laser sound")
     elseif turret.kind == "salvaging_laser" then
-        Sound.triggerEvent('weapon_salvaging_laser', x, y)
+        if turret.salvagingSoundInstance then
+            TurretEffects.stopSalvagingSound(turret)
+        end
+        turret.salvagingSoundInstance = Sound.triggerEvent('weapon_salvaging_laser', x, y)
+        if turret.salvagingSoundInstance then
+            turret.salvagingSoundActive = true
+        end
     end
 end
 
@@ -46,6 +52,24 @@ function TurretEffects.stopMiningSound(turret)
         turret.miningSoundActive = false
         Log.debug("Stopped mining laser sound")
     end
+end
+
+-- Stop salvaging laser sound
+function TurretEffects.stopSalvagingSound(turret)
+    if not turret then
+        return
+    end
+
+    if turret.salvagingSoundInstance and turret.salvagingSoundInstance.stop then
+        turret.salvagingSoundInstance:stop()
+    end
+
+    if turret.salvagingSoundInstance then
+        Log.debug("Stopped salvaging laser sound")
+    end
+
+    turret.salvagingSoundInstance = nil
+    turret.salvagingSoundActive = false
 end
 
 -- Stop all mining sounds (cleanup function)


### PR DESCRIPTION
## Summary
- add a shared helper that checks whether a utility turret is actively commanded to fire before running mining or salvaging beam logic
- gate mining and salvaging beam audio on active input and stop the loops when energy, lock, or other conditions prevent firing
- persist salvaging beam sound instances so they can be stopped cleanly when the beam ends

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e0e2ee5704832299d4614ed1cb349f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates mining/salvaging beam logic and looping audio on active input, and persists/stops salvaging laser sound instances cleanly.
> 
> - **Utility Beams (`src/systems/turret/utility_beams.lua`)**:
>   - Add `isTurretInputActive(turret)` helper and require active input to run `updateMiningLaser`/`updateSalvagingLaser`.
>   - Start mining/salvaging audio only when input is active; stop loops on lock, energy depletion, or when beam deactivates.
>   - Clear salvage flags and stop salvaging sound when beam halts; guard cooldown/audio with `wasActive` checks.
> - **Effects (`src/systems/turret/effects.lua`)**:
>   - Persist salvaging laser sound via `turret.salvagingSoundInstance` and track `salvagingSoundActive`.
>   - Add `TurretEffects.stopSalvagingSound(turret)` and invoke before starting new instance.
>   - Keep existing mining sound lifecycle; refine start/stop handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c560fd3abe05c5e693b63d20196f9c2d10a68d71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->