### PR TITLE
Handle Multiplayer Join Failures Gracefully

### DIFF
--- a/src/ui/start_screen.lua
+++ b/src/ui/start_screen.lua
@@ -77,6 +77,7 @@ local startScreenHandler = function(self, x, y, button)
   if Theme.handleButtonClick(self.multiplayerButton, x, y, function()
     print("Join Game button clicked, opening UI")
     self.showJoinUI = true
+    self.joinErrorMessage = nil
   end) then
     return false
   end
@@ -187,6 +188,7 @@ function Start.new()
   self.showJoinUI = false
   self.joinAddress = "localhost"
   self.joinPort = "7777"
+  self.joinErrorMessage = nil
   -- Create a temporary network manager for the start screen
   self.networkManager = NetworkManager.new()
   self.versionWindow = Window.new({
@@ -557,11 +559,18 @@ function Start:drawJoinUI()
   -- Port text
   Theme.setColor(Theme.colors.text)
   love.graphics.print(self.joinPort, portX + 5 * s, portY + 5 * s)
-  
+
+  if self.joinErrorMessage then
+    Theme.setColor(Theme.colors.danger)
+    local messageY = portY + portH + 10 * s
+    love.graphics.printf(self.joinErrorMessage, windowX + 20 * s, messageY, windowW - 40 * s, "center")
+  end
+
   -- Buttons
   local buttonW = 80 * s
   local buttonH = 30 * s
-  local buttonY = portY + 50 * s
+  local buttonYOffset = self.joinErrorMessage and 80 * s or 50 * s
+  local buttonY = portY + buttonYOffset
   local joinX = windowX + (windowW - buttonW * 2 - 20 * s) / 2
   local cancelX = joinX + buttonW + 20 * s
   
@@ -610,7 +619,9 @@ function Start:mousepressed(x, y, button)
       print("Join button bounds:", self.joinButton.x, self.joinButton.y, self.joinButton.w, self.joinButton.h)
       local port = tonumber(self.joinPort) or 7777
       print("Attempting to join game at", self.joinAddress, port)
-      
+
+      self.joinErrorMessage = nil
+
       -- Store connection info globally for Game.load to use
       _G.PENDING_MULTIPLAYER_CONNECTION = {
         address = self.joinAddress,
@@ -629,6 +640,8 @@ function Start:mousepressed(x, y, button)
       -- Cancel button clicked
       print("Cancel button clicked")
       self.showJoinUI = false
+      self.joinErrorMessage = nil
+      _G.PENDING_MULTIPLAYER_CONNECTION = nil
       return false
     end
     print("No button clicked in multiplayer UI")
@@ -731,6 +744,11 @@ function Start:wheelmoved(x, y, dx, dy)
   end
 
   return false
+end
+
+function Start:onJoinFailed(message)
+  self.joinErrorMessage = message or "Failed to connect to server."
+  self.showJoinUI = true
 end
 
 function Start:keypressed(key)


### PR DESCRIPTION
## Summary
- clear pending multiplayer join state when the client fails to connect and reopen the join dialog with context-aware messaging
- surface join failure feedback directly inside the start screen multiplayer modal so players can retry without unintended game starts

## Testing
- not run (explain why): manual Love2D runtime not available in this environment

------
https://chatgpt.com/codex/tasks/task_b_68e16b1e07c88322b3912e953d82b8b7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows join failure messages in the start screen modal and clears pending multiplayer connections when client join fails.
> 
> - **Multiplayer join failure handling**:
>   - **Core** (`src/core/input.lua`):
>     - Add `handleMultiplayerJoinFailure` to clear `'_G.PENDING_MULTIPLAYER_CONNECTION'` and notify start screen via `startScreen:onJoinFailed(...)`.
>     - On `Game.load` failure/false for client joins, trigger context-specific messages and keep user on start screen; refine error notification text creation.
>   - **UI** (`src/ui/start_screen.lua`):
>     - Track `self.joinErrorMessage`; reset on open/cancel/join click; clear pending connection on cancel.
>     - Display error message in join modal and shift buttons accordingly.
>     - Add `Start:onJoinFailed(message)` to reopen join modal with message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b6cccdae4ddf0758918bade726fb8cc12d103d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->