### PR TITLE
Require Multiplayer Join Handshake

### DIFF
--- a/src/core/input.lua
+++ b/src/core/input.lua
@@ -123,6 +123,16 @@ local function transitionToGame(opts)
     local loadingScreen = mainState.loadingScreen
     local Game = require("src.game")
 
+    local function handleMultiplayerJoinFailure(message)
+        if _G.PENDING_MULTIPLAYER_CONNECTION then
+            _G.PENDING_MULTIPLAYER_CONNECTION = nil
+        end
+
+        if mainState.startScreen and mainState.startScreen.onJoinFailed then
+            mainState.startScreen:onJoinFailed(message)
+        end
+    end
+
     if loadingScreen then
         local loadingText = multiplayer and (isHost and "Starting multiplayer server..." or "Joining multiplayer game...") or "Loading..."
         loadingScreen:show({loadingText}, false)
@@ -139,7 +149,7 @@ local function transitionToGame(opts)
         return Game.load(false, nil, loadingScreen, multiplayer, isHost)
     end
 
-    local success, result = pcall(performLoad)
+    local success, result, detail = pcall(performLoad)
 
     if loadingScreen then
         loadingScreen:hide()
@@ -148,11 +158,27 @@ local function transitionToGame(opts)
     -- Check if Game.load() succeeded
     if not success then
         Log.error("Game.load() failed with error:", result)
-        Notifications.add("Failed to load game: " .. tostring(result), "error")
+        local errorMessage = "Failed to load game: " .. tostring(result)
+        Notifications.add(errorMessage, "error")
+        if multiplayer and not isHost then
+            handleMultiplayerJoinFailure(result or "Failed to connect to server. Please check the address and try again.")
+        end
         return false
     elseif result == false then
-        Log.error("Game.load() returned false - connection failed")
-        Notifications.add("Failed to connect to server", "error")
+        local failureMessage = detail
+        if not failureMessage then
+            if multiplayer and not isHost then
+                failureMessage = "Failed to connect to server"
+            else
+                failureMessage = "Failed to load game"
+            end
+        end
+
+        Log.error("Game.load() returned false", failureMessage)
+        Notifications.add(failureMessage, "error")
+        if multiplayer and not isHost then
+            handleMultiplayerJoinFailure(failureMessage)
+        end
         return false
     end
 

--- a/src/core/network/manager.lua
+++ b/src/core/network/manager.lua
@@ -94,10 +94,10 @@ function NetworkManager:startHost(port)
     return false
 end
 
-function NetworkManager:joinGame(address, port)
+function NetworkManager:joinGame(address, port, options)
     if self._isMultiplayer then
         Log.warn("Already in multiplayer mode")
-        return false
+        return false, "Already connected to a multiplayer session."
     end
 
     address = address or "localhost"
@@ -105,15 +105,19 @@ function NetworkManager:joinGame(address, port)
 
     Log.info("Attempting to join game at", string.format("%s:%d", address, port))
 
-    if self.client:connect(address, port) then
+    local connected, err = self.client:connect(address, port, options)
+    if connected then
         self._isHost = false
         self._isMultiplayer = true
         Log.info("Successfully joined multiplayer game as CLIENT - isHost:", self._isHost, "isMultiplayer:", self._isMultiplayer)
         return true
     end
 
-    Log.error("Failed to join multiplayer game")
-    return false
+    local message = err or self.client:getLastError() or "Failed to join multiplayer game."
+    Log.error("Failed to join multiplayer game:", message)
+    self._isHost = false
+    self._isMultiplayer = false
+    return false, message
 end
 
 function NetworkManager:leaveGame()

--- a/src/game.lua
+++ b/src/game.lua
@@ -324,22 +324,22 @@ function Game.load(fromSave, saveSlot, loadingScreen, multiplayer, isHost)
       Log.info("Attempting connection to server from start screen parameters")
       Log.info("Connection details:", _G.PENDING_MULTIPLAYER_CONNECTION.address, _G.PENDING_MULTIPLAYER_CONNECTION.port)
       -- Attempt the connection to the server
-      local connectionResult = networkManager:joinGame(_G.PENDING_MULTIPLAYER_CONNECTION.address, _G.PENDING_MULTIPLAYER_CONNECTION.port)
-      Log.info("Connection result:", connectionResult)
+      local connectionResult, connectionError = networkManager:joinGame(_G.PENDING_MULTIPLAYER_CONNECTION.address, _G.PENDING_MULTIPLAYER_CONNECTION.port)
+      Log.info("Connection result:", connectionResult, connectionError)
       if connectionResult then
         Log.info("Successfully connected to server")
         -- Ensure the game knows it's in client mode
         Game.setMultiplayerMode(true, false)
         _G.PENDING_MULTIPLAYER_CONNECTION = nil -- Clear the pending connection
       else
-        Log.error("Failed to connect to server - aborting game load")
+        Log.error("Failed to connect to server - aborting game load", connectionError)
         -- Connection failed, don't load the game
-        return false
+        return false, connectionError
       end
     else
       Log.error("No pending connection found for client mode - aborting game load")
       -- No connection to attempt, don't load the game
-      return false
+      return false, "No pending connection details found."
     end
   end
   


### PR DESCRIPTION
## Summary
- add a blocking ENet handshake with timeout, error tracking, and event queueing so multiplayer client joins only succeed when a server acknowledges the connection
- surface join failure reasons through the network manager, game loader, and start screen UI so players see accurate error messaging when a server is unavailable

## Testing
- not run (explain why): Love2D runtime is unavailable in this environment

------
https://chatgpt.com/codex/tasks/task_b_68e16b1e07c88322b3912e953d82b8b7