### PR TITLE
Use stored remote snapshots for player sync

### DIFF
--- a/src/systems/network_sync.lua
+++ b/src/systems/network_sync.lua
@@ -12,6 +12,8 @@ local NetworkSync = {}
 local storeRemoteSnapshot
 local updateRemotePlayer
 local createRemotePlayer
+local getLocalPlayerCanonicalId
+local resolvePlayerSnapshot
 
 -- Remote players storage
 local remotePlayers = {}
@@ -215,6 +217,38 @@ createRemotePlayer = function(playerId, data, world)
     return remotePlayer
 end
 
+getLocalPlayerCanonicalId = function(networkManager)
+    if not networkManager then
+        return nil
+    end
+
+    if networkManager:isHost() then
+        return canonicalizePlayerId(0)
+    end
+
+    if networkManager.client and networkManager.client.playerId then
+        return canonicalizePlayerId(networkManager.client.playerId)
+    end
+
+    return nil
+end
+
+resolvePlayerSnapshot = function(playerData)
+    if not playerData then
+        return nil
+    end
+
+    if playerData.position then
+        return playerData
+    end
+
+    if playerData.data and playerData.data.position then
+        return playerData.data
+    end
+
+    return nil
+end
+
 -- Listen for incoming player updates
 Events.on("NETWORK_PLAYER_UPDATED", function(data)
     Log.info("NETWORK_PLAYER_UPDATED received:", data and data.playerId or "nil")
@@ -282,19 +316,44 @@ function NetworkSync.update(dt, player, world, networkManager)
     local playerCount = 0
     for _ in pairs(players) do playerCount = playerCount + 1 end
     Log.info("NetworkSync: Found", playerCount, "players from network manager")
-    
+
+    local localCanonicalId = getLocalPlayerCanonicalId(networkManager)
+
     for playerId, playerData in pairs(players) do
         local canonicalId = normalizePlayerDataId(playerData, playerId)
-        local snapshot = playerData
-        Log.info("Processing player:", canonicalId, "has position:", snapshot and snapshot.position ~= nil)
-        Log.info("Player data structure:", json.encode(playerData))
-        if snapshot and snapshot.position then
-            updateRemotePlayer(canonicalId, snapshot, world)
-        elseif snapshot and snapshot.data and snapshot.data.position then
-            updateRemotePlayer(canonicalId, snapshot.data, world)
+
+        if canonicalId and localCanonicalId and canonicalId == localCanonicalId then
+            Log.info("Skipping local player from remote sync:", canonicalId)
+
+            -- Ensure we remove any stale remote entity or snapshot that may have been created for the local player
+            if remotePlayers[canonicalId] then
+                Log.info("Removing stale local remote player entity:", canonicalId)
+                if world then
+                    world:removeEntity(remotePlayers[canonicalId])
+                end
+                remotePlayers[canonicalId] = nil
+            end
+            remotePlayerSnapshots[canonicalId] = nil
         else
-            -- Even if we don't yet have full position data, keep the latest identifiers around
-            storeRemoteSnapshot(canonicalId, playerData)
+            if canonicalId then
+                local snapshot = resolvePlayerSnapshot(playerData)
+
+                if not snapshot then
+                    snapshot = remotePlayerSnapshots[canonicalId]
+                    if snapshot then
+                        Log.info("Using stored snapshot for remote player:", canonicalId)
+                    end
+                end
+
+                if snapshot then
+                    Log.info("Processing player:", canonicalId, "has position:", snapshot.position ~= nil)
+                    Log.info("Player data structure:", json.encode(playerData))
+                    updateRemotePlayer(canonicalId, snapshot, world)
+                else
+                    -- Even if we don't yet have full position data, keep the latest identifiers around
+                    storeRemoteSnapshot(canonicalId, playerData)
+                end
+            end
         end
     end
 
@@ -307,7 +366,7 @@ function NetworkSync.update(dt, player, world, networkManager)
                 break
             end
         end
-        
+
         if not stillConnected then
             Log.info("Removing disconnected remote player:", playerId)
             if world then


### PR DESCRIPTION
## Summary
- add a helper to resolve incoming player data into a usable snapshot
- fall back to cached remote snapshots when network listings lack position data so remote ships keep updating

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2184d6b288322af02abada021e596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `resolvePlayerSnapshot` to extract a usable snapshot (with `position`) from incoming player data, handling nested `data` structures.
> 
> - **Network Sync (`src/systems/network_sync.lua`)**:
>   - **Helper**: Add `resolvePlayerSnapshot(playerData)` to resolve a usable snapshot:
>     - Returns `playerData` if it contains `position`.
>     - Falls back to `playerData.data` if it contains `position`.
>     - Returns `nil` otherwise.
>   - Declare `resolvePlayerSnapshot` alongside other local function forwards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f2b3b4f8d16385bfac25625319c04a615992305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->