### PR TITLE
Refactor multiplayer networking stack

### DIFF
--- a/src/core/network/client.lua
+++ b/src/core/network/client.lua
@@ -1,476 +1,80 @@
 --[[
     Network Client
-    Handles client-side networking for multiplayer gameplay
+    Minimal ENet client that exchanges player state snapshots with the host.
 ]]
 
 local Log = require("src.core.log")
 local Events = require("src.core.events")
-local json = require("src.libs.json")
+local Messages = require("src.core.network.messages")
+
+local TYPES = Messages.TYPES
 
 local NetworkClient = {}
 NetworkClient.__index = NetworkClient
 
--- Connection states
-local CONNECTION_STATES = {
-    DISCONNECTED = "disconnected",
-    CONNECTING = "connecting",
-    CONNECTED = "connected",
-    ERROR = "error"
-}
-
--- Message types
-local MESSAGE_TYPES = {
-    PLAYER_JOIN = "player_join",
-    PLAYER_LEAVE = "player_leave",
-    PLAYER_UPDATE = "player_update",
-    PING = "ping",
-    PONG = "pong"
-}
-
-local function currentTime()
-    if love and love.timer and love.timer.getTime then
-        return love.timer.getTime()
-    end
-    return os.clock()
-end
-
-local function randomPlayerName()
-    -- Use timestamp, random number, and process ID to ensure uniqueness across instances
-    local timestamp = os.time()
-    local random = math.random(1000, 9999)
-    local pid = (love and love.timer and love.timer.getTime and math.floor(love.timer.getTime() * 1000)) or math.random(100000, 999999)
-    return "Player_" .. timestamp .. "_" .. random .. "_" .. pid
-end
-
-local function mergePlayerSnapshot(store, playerId, snapshot, playerName)
-    if not playerId then
+local function sanitiseState(state)
+    if type(state) ~= "table" then
         return nil
     end
 
-    local entry = store[playerId] or {}
+    local position = state.position or {}
+    local velocity = state.velocity or {}
 
-    if snapshot then
-        for key, value in pairs(snapshot) do
-            entry[key] = value
+    return {
+        position = {
+            x = tonumber(position.x) or 0,
+            y = tonumber(position.y) or 0,
+            angle = tonumber(position.angle) or 0
+        },
+        velocity = {
+            x = tonumber(velocity.x) or 0,
+            y = tonumber(velocity.y) or 0
+        },
+        name = state.name
+    }
+end
+
+local function buildIndex(snapshot)
+    local out = {}
+    if type(snapshot) ~= "table" then
+        return out
+    end
+
+    for _, entry in ipairs(snapshot) do
+        if entry.playerId ~= nil and entry.state then
+            out[entry.playerId] = {
+                playerId = entry.playerId,
+                name = entry.name,
+                state = sanitiseState(entry.state) or {
+                    position = { x = 0, y = 0, angle = 0 },
+                    velocity = { x = 0, y = 0 }
+                }
+            }
         end
     end
+    return out
+end
 
-    entry.playerId = entry.playerId or playerId
-    if playerName then
-        entry.playerName = playerName
-    end
-
-    store[playerId] = entry
-    return entry
+local function randomName()
+    return string.format("Pilot_%d", love and love.timer and love.timer.getTime and math.floor(love.timer.getTime() * 1000) or os.time())
 end
 
 function NetworkClient.new()
     local self = setmetatable({}, NetworkClient)
 
-    self.state = CONNECTION_STATES.DISCONNECTED
-    self.serverAddress = "localhost"
-    self.serverPort = 7777
+    self.transport = nil
+    self.enetClient = nil
     self.playerId = nil
     self.players = {}
-    self.lastPingTime = 0
-    self.ping = 0
-
-    self.transport = "none"
-    self.fileNetwork = nil
-    self.pendingJoinPayload = nil
-    self.localPlayerName = nil
-    self.pendingEnetEvents = nil
+    self.connected = false
     self.lastError = nil
+    self.localName = randomName()
 
     return self
 end
 
-function NetworkClient:_cleanupTransport(emitEvents)
-    if self.transport == "enet" and self.enetClient then
-        local EnetTransport = require("src.core.network.transport.enet")
-        EnetTransport.disconnectClient(self.enetClient)
-        EnetTransport.destroy(self.enetClient)
-        self.enetClient = nil
-    end
-
-    self.transport = "none"
-    self.state = CONNECTION_STATES.DISCONNECTED
-    self.playerId = nil
-    self.players = {}
-    self.pendingJoinPayload = nil
-    self.localPlayerName = nil
-    self.pendingEnetEvents = nil
-    self.lastPingTime = 0
-    self.ping = 0
-
-    if emitEvents then
-        Log.info("Disconnected from server")
-        Events.emit("NETWORK_DISCONNECTED")
-    end
-end
-
-local function formatEndpoint(address, port)
-    return string.format("%s:%d", address, port)
-end
-
-local function pollTimeoutSeconds(options)
-    local defaultTimeout = 5
-
-    if not options then
-        return defaultTimeout
-    end
-
-    if options.handshakeTimeout == 0 or options.timeout == 0 then
-        return 0
-    end
-
-    local timeout = options.handshakeTimeout or options.timeout or defaultTimeout
-    if type(timeout) ~= "number" then
-        return defaultTimeout
-    end
-
-    if timeout < 0 then
-        return defaultTimeout
-    end
-
-    return timeout == 0 and 0 or timeout
-end
-
-local function clampTimeout(timeout)
-    if not timeout or timeout <= 0 then
-        return 0
-    end
-    -- Prevent excessively long blocking periods; ENet has its own internal timeout
-    return math.min(timeout, 10)
-end
-
-local function milliseconds(value)
-    if not value or value <= 0 then
-        return 0
-    end
-    return math.floor(value * 1000)
-end
-
-local function captureTime()
-    if love and love.timer and love.timer.getTime then
-        return love.timer.getTime()
-    end
-    return os.clock()
-end
-
-function NetworkClient:connect(address, port, options)
-    if self.state == CONNECTION_STATES.CONNECTED or self.state == CONNECTION_STATES.CONNECTING then
-        Log.warn("Client already attempting or holding a connection")
-        self.lastError = "Client already attempting or holding a connection."
-        return false, self.lastError
-    end
-
-    self.serverAddress = address or self.serverAddress
-    self.serverPort = port or self.serverPort
-    self.state = CONNECTION_STATES.CONNECTING
-    self.playerId = nil
-    self.players = {}
-    self.lastPingTime = 0
-    self.ping = 0
-    self.pendingEnetEvents = nil
-    self.lastError = nil
-
-    self.pendingJoinPayload = {
-        type = MESSAGE_TYPES.PLAYER_JOIN,
-        playerName = randomPlayerName(),
-        data = {
-            position = { x = 0, y = 0, angle = 0 },
-            velocity = { x = 0, y = 0 },
-            health = { hp = 100, maxHp = 100, shield = 0, maxShield = 0 }
-        },
-        timestamp = currentTime()
-    }
-    self.localPlayerName = self.pendingJoinPayload.playerName
-
-    Log.info("Connecting to server at", formatEndpoint(self.serverAddress, self.serverPort))
-
-    -- Try ENet transport first
-    local ok, EnetTransport = pcall(require, "src.core.network.transport.enet")
-    Log.info("ENet transport check - ok:", ok, "EnetTransport:", EnetTransport and "loaded" or "nil")
-    if ok and EnetTransport then
-        Log.info("ENet transport available:", EnetTransport.isAvailable())
-        if not EnetTransport.isAvailable() then
-            Log.warn("ENet transport loaded but not available - lua-enet library may not be compiled")
-        end
-    else
-        Log.warn("Failed to load ENet transport - lua-enet library not available")
-    end
-    if ok and EnetTransport and EnetTransport.isAvailable() then
-        Log.info("ENet is available, attempting to create client")
-        local client, err = EnetTransport.createClient()
-        if client then
-            Log.info("ENet client created, attempting to connect to", self.serverAddress, self.serverPort)
-            local peer, peerErr = EnetTransport.connect(client, self.serverAddress, self.serverPort)
-            if peer then
-                self.enetClient = client
-                self.transport = "enet"
-
-                local handshakeTimeout = clampTimeout(pollTimeoutSeconds(options))
-                local deadline = handshakeTimeout > 0 and (captureTime() + handshakeTimeout) or nil
-                local connected = false
-                self.pendingEnetEvents = {}
-
-                while true do
-                    local waitMs = 100
-                    if deadline then
-                        local remaining = deadline - captureTime()
-                        if remaining <= 0 then
-                            break
-                        end
-                        waitMs = math.max(10, math.min(milliseconds(remaining), 250))
-                    end
-
-                    local event = EnetTransport.service(self.enetClient, waitMs)
-                    if event then
-                        if event.type == "connect" then
-                            connected = true
-                            break
-                        elseif event.type == "disconnect" then
-                            self.lastError = "Server rejected connection request."
-                            break
-                        else
-                            table.insert(self.pendingEnetEvents, event)
-                        end
-                    elseif not deadline then
-                        -- No events and no deadline specified; treat as immediate failure
-                        break
-                    end
-                end
-
-                if connected then
-                    self.state = CONNECTION_STATES.CONNECTED
-                    self.lastError = nil
-                    Log.info("Connected using ENet transport")
-                    Events.emit("NETWORK_CONNECTED")
-                    if self.pendingJoinPayload then
-                        self:sendMessage(self.pendingJoinPayload)
-                        self.pendingJoinPayload = nil
-                    end
-
-                    if self.pendingEnetEvents and #self.pendingEnetEvents > 0 then
-                        for _, pendingEvent in ipairs(self.pendingEnetEvents) do
-                            self:_processEnetEvent(pendingEvent)
-                        end
-                    end
-                    self.pendingEnetEvents = nil
-
-                    return true
-                end
-
-                if not self.lastError then
-                    local timeoutMessage = string.format("Connection attempt to %s:%d timed out.", self.serverAddress, self.serverPort)
-                    if deadline then
-                        timeoutMessage = timeoutMessage .. string.format(" (%.1fs)", handshakeTimeout)
-                    end
-                    self.lastError = timeoutMessage
-                end
-
-                self:_cleanupTransport(false)
-                return false, self.lastError
-            else
-                Log.error("Failed to connect with ENet:", peerErr)
-                self.lastError = peerErr and tostring(peerErr) or "Failed to initiate connection."
-                self:_cleanupTransport(false)
-                return false, self.lastError
-            end
-        else
-            Log.error("Failed to create ENet client:", err)
-            self.lastError = err and tostring(err) or "Unable to create network client."
-            return false, self.lastError
-        end
-    else
-        Log.error("ENet transport not available - ok:", ok, "EnetTransport:", EnetTransport and "loaded" or "nil")
-        if EnetTransport then
-            Log.error("ENet isAvailable:", EnetTransport.isAvailable())
-        end
-        self.lastError = "Network transport unavailable."
-    end
-
-    Log.error("No networking transport available for", self.serverAddress)
-    return false, self.lastError
-end
-
-function NetworkClient:disconnect()
-    if self.transport == "enet" and self.enetClient and self.state == CONNECTION_STATES.CONNECTED then
-        self:sendMessage({
-            type = MESSAGE_TYPES.PLAYER_LEAVE,
-            playerId = self.playerId,
-            timestamp = currentTime()
-        })
-    end
-
-    self:_cleanupTransport(true)
-end
-
-function NetworkClient:sendMessage(message)
-    if self.state ~= CONNECTION_STATES.CONNECTED then
-        return false
-    end
-
-    if self.transport == "enet" and self.enetClient then
-        local EnetTransport = require("src.core.network.transport.enet")
-        local json = require("src.libs.json")
-        local data = json.encode(message)
-        local success, err = EnetTransport.send(self.enetClient, data, 0, true)
-        if not success then
-            Log.warn("Failed to send message via ENet transport:", err)
-            return false
-        end
-        return true
-    end
-
-    return false
-end
-
-function NetworkClient:_processEnetEvent(event)
-    if not event then
-        return
-    end
-
-    if event.type == "connect" then
-        Log.info("Received ENet connect event")
-        if self.state ~= CONNECTION_STATES.CONNECTED then
-            self.state = CONNECTION_STATES.CONNECTED
-            self.lastError = nil
-            Events.emit("NETWORK_CONNECTED")
-            if self.pendingJoinPayload then
-                self:sendMessage(self.pendingJoinPayload)
-                self.pendingJoinPayload = nil
-            end
-        end
-        return
-    end
-
-    if event.type == "disconnect" then
-        Log.info("Disconnected from server")
-        self.state = CONNECTION_STATES.DISCONNECTED
-        self.lastError = "Disconnected from server"
-        Events.emit("NETWORK_DISCONNECTED")
-        return
-    end
-
-    if event.type == "receive" then
-        local success, message = pcall(json.decode, event.data)
-        if success and message then
-            self:handleMessage(message)
-        end
-    end
-end
-
-function NetworkClient:update(dt)
-    if self.state == CONNECTION_STATES.DISCONNECTED then
-        return
-    end
-
-    if self.transport == "enet" and self.enetClient then
-        local EnetTransport = require("src.core.network.transport.enet")
-        if self.pendingEnetEvents and #self.pendingEnetEvents > 0 then
-            for _, pendingEvent in ipairs(self.pendingEnetEvents) do
-                self:_processEnetEvent(pendingEvent)
-            end
-            self.pendingEnetEvents = nil
-        end
-
-        -- Poll for ENet events
-        local event = EnetTransport.service(self.enetClient, 0)
-        while event do
-            self:_processEnetEvent(event)
-            event = EnetTransport.service(self.enetClient, 0)
-        end
-    end
-
-    if self.state == CONNECTION_STATES.CONNECTED then
-        self.lastPingTime = self.lastPingTime + dt
-        if self.lastPingTime >= 5.0 then
-            self:sendMessage({
-                type = MESSAGE_TYPES.PING,
-                timestamp = currentTime()
-            })
-            self.lastPingTime = 0
-        end
-    end
-end
-
-function NetworkClient:handleMessage(message)
-    if message.type == MESSAGE_TYPES.PLAYER_JOIN then
-        if not self.playerId then
-            self.playerId = message.playerId
-            Log.info("Assigned player ID:", self.playerId)
-
-            if message.players then
-                Log.info("Client received", #message.players, "existing players from server")
-                for _, entry in ipairs(message.players) do
-                    Log.info("Processing existing player:", entry.playerId, "name:", entry.name)
-                    mergePlayerSnapshot(self.players, entry.playerId, entry.data, entry.name)
-                    Events.emit("NETWORK_PLAYER_JOINED", {
-                        playerId = entry.playerId,
-                        playerName = entry.name,
-                        isSelf = false
-                    })
-                end
-            end
-
-            Events.emit("NETWORK_PLAYER_JOINED", {
-                playerId = self.playerId,
-                playerName = self.localPlayerName,
-                isSelf = true
-            })
-        elseif message.playerId and message.playerId ~= self.playerId then
-            if not self.players[message.playerId] then
-                Log.info("Player joined:", message.playerName or message.playerId)
-            end
-            mergePlayerSnapshot(self.players, message.playerId, message.data, message.playerName)
-            Events.emit("NETWORK_PLAYER_JOINED", {
-                playerId = message.playerId,
-                playerName = message.playerName,
-                isSelf = false
-            })
-        end
-
-    elseif message.type == MESSAGE_TYPES.PLAYER_LEAVE then
-        if self.players[message.playerId] then
-            self.players[message.playerId] = nil
-            Log.info("Player left:", message.playerId)
-            Events.emit("NETWORK_PLAYER_LEFT", { playerId = message.playerId })
-        end
-
-    elseif message.type == MESSAGE_TYPES.PLAYER_UPDATE then
-        if message.playerId ~= self.playerId then
-            local snapshot = mergePlayerSnapshot(self.players, message.playerId, message.data)
-            Events.emit("NETWORK_PLAYER_UPDATED", {
-                playerId = message.playerId,
-                data = snapshot
-            })
-        end
-
-
-    elseif message.type == MESSAGE_TYPES.PONG then
-        self.ping = (currentTime() - message.timestamp) * 1000
-        Events.emit("NETWORK_PING_UPDATED", { ping = self.ping })
-    end
-end
-
-function NetworkClient:sendPlayerUpdate(playerData)
-    if not self.playerId then
-        return
-    end
-
-    self:sendMessage({
-        type = MESSAGE_TYPES.PLAYER_UPDATE,
-        playerId = self.playerId,
-        data = playerData,
-        timestamp = currentTime()
-    })
-end
-
-
-function NetworkClient:getState()
-    return self.state
+function NetworkClient:isConnected()
+    return self.connected and self.enetClient ~= nil
 end
 
 function NetworkClient:getPlayers()
@@ -478,15 +82,175 @@ function NetworkClient:getPlayers()
 end
 
 function NetworkClient:getPing()
-    return self.ping
-end
-
-function NetworkClient:isConnected()
-    return self.state == CONNECTION_STATES.CONNECTED
+    if self.enetClient and self.enetClient.peer then
+        return self.enetClient.peer:round_trip_time() or 0
+    end
+    return 0
 end
 
 function NetworkClient:getLastError()
     return self.lastError
+end
+
+function NetworkClient:connect(address, port)
+    if self:isConnected() then
+        return true
+    end
+
+    local ok, EnetTransport = pcall(require, "src.core.network.transport.enet")
+    if not ok or not EnetTransport or not EnetTransport.isAvailable() then
+        self.lastError = "ENet transport not available"
+        return false, self.lastError
+    end
+
+    local client, err = EnetTransport.createClient()
+    if not client then
+        self.lastError = err
+        return false, err
+    end
+
+    local peer, connectErr = EnetTransport.connect(client, address or "localhost", port or 7777)
+    if not peer then
+        self.lastError = connectErr
+        return false, connectErr
+    end
+
+    self.transport = EnetTransport
+    self.enetClient = client
+    self.connected = true
+    self.players = {}
+
+    Log.info("Connecting to", address or "localhost", port or 7777)
+
+    return true
+end
+
+function NetworkClient:_send(payload)
+    if not self:isConnected() then
+        return
+    end
+
+    local encoded = Messages.encode(payload)
+    if not encoded then
+        return
+    end
+
+    local ok, err = self.transport.send(self.enetClient, encoded, 0, true)
+    if not ok then
+        Log.warn("Failed to send payload:", err)
+    end
+end
+
+function NetworkClient:disconnect()
+    if not self:isConnected() then
+        return
+    end
+
+    self:_send({ type = TYPES.GOODBYE, playerId = self.playerId })
+
+    self.transport.disconnectClient(self.enetClient)
+    self.transport.destroy(self.enetClient)
+
+    self.transport = nil
+    self.enetClient = nil
+    self.connected = false
+    self.playerId = nil
+    self.players = {}
+
+    Events.emit("NETWORK_DISCONNECTED")
+end
+
+function NetworkClient:update(dt)
+    if not self:isConnected() then
+        return
+    end
+
+    local event = self.transport.service(self.enetClient, 0)
+    while event do
+        if event.type == "connect" then
+            self:_send({
+                type = TYPES.HELLO,
+                name = self.localName,
+                state = {
+                    position = { x = 0, y = 0, angle = 0 },
+                    velocity = { x = 0, y = 0 }
+                }
+            })
+            Events.emit("NETWORK_CONNECTED")
+        elseif event.type == "disconnect" then
+            Log.warn("Disconnected from server")
+            self:disconnect()
+            return
+        elseif event.type == "receive" then
+            local message = Messages.decode(event.data)
+            if message then
+                self:_handleMessage(message)
+            end
+        end
+
+        event = self.transport.service(self.enetClient, 0)
+    end
+end
+
+function NetworkClient:_handleMessage(message)
+    if message.type == TYPES.WELCOME then
+        self.playerId = message.playerId
+        self.players = buildIndex(message.players)
+
+        Events.emit("NETWORK_PLAYER_JOINED", {
+            playerId = self.playerId,
+            isSelf = true,
+            playerName = self.localName
+        })
+
+        for _, entry in ipairs(message.players or {}) do
+            if entry.playerId ~= self.playerId then
+                Events.emit("NETWORK_PLAYER_JOINED", {
+                    playerId = entry.playerId,
+                    playerName = entry.name,
+                    data = entry.state
+                })
+            end
+        end
+    elseif message.type == TYPES.STATE then
+        if message.playerId == self.playerId then
+            return
+        end
+
+        if not self.players[message.playerId] then
+            self.players[message.playerId] = {
+                playerId = message.playerId,
+                name = message.name or string.format("Player %s", tostring(message.playerId)),
+                state = sanitiseState(message.state) or {
+                    position = { x = 0, y = 0, angle = 0 },
+                    velocity = { x = 0, y = 0 }
+                }
+            }
+        else
+            self.players[message.playerId].state = sanitiseState(message.state) or self.players[message.playerId].state
+        end
+
+        Events.emit("NETWORK_PLAYER_UPDATED", {
+            playerId = message.playerId,
+            data = self.players[message.playerId].state,
+            playerName = self.players[message.playerId].name
+        })
+    elseif message.type == TYPES.GOODBYE then
+        self.players[message.playerId] = nil
+        Events.emit("NETWORK_PLAYER_LEFT", { playerId = message.playerId })
+    end
+end
+
+function NetworkClient:sendPlayerUpdate(state)
+    if not self:isConnected() then
+        return
+    end
+
+    self:_send({
+        type = TYPES.STATE,
+        playerId = self.playerId,
+        state = sanitiseState(state)
+    })
 end
 
 return NetworkClient

--- a/src/core/network/messages.lua
+++ b/src/core/network/messages.lua
@@ -1,0 +1,26 @@
+local Messages = {}
+
+Messages.TYPES = {
+    HELLO = "hello",
+    WELCOME = "welcome",
+    STATE = "state",
+    GOODBYE = "goodbye",
+    PING = "ping",
+    PONG = "pong"
+}
+
+function Messages.encode(payload)
+    local json = require("src.libs.json")
+    return json.encode(payload)
+end
+
+function Messages.decode(data)
+    local json = require("src.libs.json")
+    local ok, value = pcall(json.decode, data)
+    if ok then
+        return value
+    end
+    return nil
+end
+
+return Messages

--- a/src/core/network/server.lua
+++ b/src/core/network/server.lua
@@ -1,86 +1,128 @@
 --[[
     Network Server
-    Handles server-side networking for multiplayer gameplay
+    Simplified authoritative host that tracks connected clients and republishes
+    lightweight player state for remote visualisation.
 ]]
 
 local Log = require("src.core.log")
 local Events = require("src.core.events")
-local json = require("src.libs.json")
+local Messages = require("src.core.network.messages")
+
+local TYPES = Messages.TYPES
 
 local NetworkServer = {}
 NetworkServer.__index = NetworkServer
 
--- Message types shared with the client
-local MESSAGE_TYPES = {
-    PLAYER_JOIN = "player_join",
-    PLAYER_LEAVE = "player_leave",
-    PLAYER_UPDATE = "player_update",
-    PING = "ping",
-    PONG = "pong"
-}
-
-local function currentTime()
+local function now()
     if love and love.timer and love.timer.getTime then
         return love.timer.getTime()
     end
     return os.clock()
 end
 
+local function canonicalPlayerId(id)
+    if id == nil then
+        return nil
+    end
+    if type(id) == "number" then
+        return id
+    end
+    if tonumber(id) then
+        return tonumber(id)
+    end
+    return id
+end
+
+local function sanitiseState(state)
+    if type(state) ~= "table" then
+        return {
+            position = { x = 0, y = 0, angle = 0 },
+            velocity = { x = 0, y = 0 }
+        }
+    end
+
+    local position = state.position or {}
+    local velocity = state.velocity or {}
+
+    return {
+        name = state.name,
+        position = {
+            x = tonumber(position.x) or 0,
+            y = tonumber(position.y) or 0,
+            angle = tonumber(position.angle) or 0
+        },
+        velocity = {
+            x = tonumber(velocity.x) or 0,
+            y = tonumber(velocity.y) or 0
+        }
+    }
+end
+
+local function buildSnapshot(players)
+    local snapshot = {}
+    for id, entry in pairs(players) do
+        snapshot[#snapshot + 1] = {
+            playerId = id,
+            name = entry.name,
+            state = entry.state
+        }
+    end
+    return snapshot
+end
 
 function NetworkServer.new(port)
     local self = setmetatable({}, NetworkServer)
 
     self.port = port or 7777
-    self.transport = "none"
-    self.fileNetwork = nil
+    self.isRunning = false
+    self.transport = nil
+    self.enetServer = nil
 
     self.players = {}
-    self.nextPlayerId = 1  -- Clients start from ID 1, host is ID 0
-    self.isRunning = false
-
-    self.lastCleanup = 0
-    self.cleanupInterval = 10.0
-
-    -- Track ENet peers so we can target responses and filter broadcasts
-    self.connectedPeers = {}
-    self.peerToPlayerId = {}
-    self.playerToPeer = {}
-
+    self.peers = {}
+    self.peerToPlayer = {}
+    self.nextPlayerId = 1
+    self.events = {}
 
     return self
 end
 
+local function pushEvent(self, kind, payload)
+    self.events[#self.events + 1] = {
+        type = kind,
+        payload = payload or {}
+    }
+end
+
 function NetworkServer:start()
     if self.isRunning then
-        Log.warn("Server already running")
+        return true
+    end
+
+    local ok, EnetTransport = pcall(require, "src.core.network.transport.enet")
+    if not ok or not EnetTransport or not EnetTransport.isAvailable() then
+        Log.error("ENet transport not available for server")
         return false
     end
 
-    Log.info("Starting server on port", self.port)
-
-    -- Try ENet transport first
-    local ok, EnetTransport = pcall(require, "src.core.network.transport.enet")
-    if ok and EnetTransport and EnetTransport.isAvailable() then
-        local server, err = EnetTransport.createServer(self.port)
-        if server then
-            self.enetServer = server
-            self.transport = "enet"
-            self.isRunning = true
-            self.connectedPeers = {}
-            self.peerToPlayerId = {}
-            self.playerToPeer = {}
-            Log.info("Server started with ENet transport on port", self.port)
-            Events.emit("NETWORK_SERVER_STARTED", { port = self.port })
-            return true
-        else
-            Log.error("Failed to create ENet server:", err)
-        end
+    local host, err = EnetTransport.createServer(self.port)
+    if not host then
+        Log.error("Failed to create ENet server:", err)
+        return false
     end
 
-    Log.error("Failed to start server - ENet transport not available")
-    self.transport = "none"
-    self.isRunning = false
-    return false
+    self.transport = EnetTransport
+    self.enetServer = host
+    self.isRunning = true
+    self.peers = {}
+    self.peerToPlayer = {}
+    self.players = {}
+    self.nextPlayerId = 1
+    self.events = {}
+
+    Log.info("Server started on port", self.port)
+    Events.emit("NETWORK_SERVER_STARTED", { port = self.port })
+    return true
 end
 
 function NetworkServer:stop()
@@ -88,345 +130,184 @@ function NetworkServer:stop()
         return
     end
 
-    if self.transport == "enet" and self.enetServer then
-        local EnetTransport = require("src.core.network.transport.enet")
-        EnetTransport.destroy(self.enetServer)
-        self.enetServer = nil
+    if self.transport and self.enetServer then
+        self.transport.destroy(self.enetServer)
     end
 
-    self.transport = "none"
+    self.transport = nil
+    self.enetServer = nil
     self.isRunning = false
     self.players = {}
+    self.peers = {}
+    self.peerToPlayer = {}
     self.nextPlayerId = 1
-    self.lastCleanup = 0
-    self.connectedPeers = {}
-    self.peerToPlayerId = {}
-    self.playerToPeer = {}
+    self.events = {}
 
     Log.info("Server stopped")
     Events.emit("NETWORK_SERVER_STOPPED")
 end
 
-local function snapshotPlayers(players, excludeId)
-    local out = {}
-    for id, player in pairs(players) do
-        if id ~= excludeId then
-            out[#out + 1] = {
-                playerId = id,
-                name = player.name,
-                data = player.data
-            }
-        end
+function NetworkServer:pullEvents()
+    if #self.events == 0 then
+        return {}
     end
-    return out
+
+    local events = self.events
+    self.events = {}
+    return events
 end
-
-local function normalizePeer(self, peerOrId)
-    if type(peerOrId) == "userdata" then
-        return peerOrId
-    end
-
-    if type(peerOrId) == "number" then
-        return self.playerToPeer[peerOrId]
-    end
-
-    if type(peerOrId) == "table" and peerOrId.peer then
-        return peerOrId.peer
-    end
-
-    return nil
-end
-
-local function registerPeerForPlayer(self, playerId, peer)
-    if not playerId or not peer or type(peer) ~= "userdata" then
-        return
-    end
-
-    -- Clear any existing peer mapping for this player to prevent stale disconnect issues
-    if self.playerToPeer[playerId] then
-        local oldPeer = self.playerToPeer[playerId]
-        self.peerToPlayerId[oldPeer] = nil
-        self.connectedPeers[oldPeer] = nil
-        Log.info("Cleared old peer mapping for player", playerId, "to prevent stale disconnect")
-    end
-
-    self.peerToPlayerId[peer] = playerId
-    self.playerToPeer[playerId] = peer
-    self.connectedPeers[peer] = true
-    Log.info("Registered new peer for player", playerId)
-end
-
-local function unregisterPeerForPlayer(self, playerId, peer)
-    local targetPeer = normalizePeer(self, peer)
-
-    if not targetPeer and playerId then
-        targetPeer = self.playerToPeer[playerId]
-    end
-
-    if targetPeer then
-        local mappedPlayerId = self.peerToPlayerId[targetPeer]
-        self.peerToPlayerId[targetPeer] = nil
-        self.connectedPeers[targetPeer] = nil
-        Log.info("Unregistered peer for player", mappedPlayerId or "unknown")
-    end
-
-    if playerId then
-        self.playerToPeer[playerId] = nil
-        Log.info("Cleared player-to-peer mapping for player", playerId)
-    end
-end
-
 
 function NetworkServer:update(dt)
-    if not self.isRunning then
+    if not self.isRunning or not self.transport or not self.enetServer then
         return
     end
 
-    if self.transport == "enet" and self.enetServer then
-        local EnetTransport = require("src.core.network.transport.enet")
-        local json = require("src.libs.json")
-
-        -- Poll for ENet events
-        local event = EnetTransport.service(self.enetServer, 0)
-        while event do
-            if event.type == "connect" then
-                Log.info("Client connected:", event.peer)
-                self.connectedPeers[event.peer] = true
-            elseif event.type == "receive" then
-                local success, message = pcall(json.decode, event.data)
-                if success and message then
-                    self:handleMessage(message, event.peer)
-                end
-            elseif event.type == "disconnect" then
-                Log.info("Client disconnected:", event.peer)
-                local playerId = self.peerToPlayerId[event.peer]
-                self.connectedPeers[event.peer] = nil
-                if playerId then
-                    -- Check if this player is still active on another peer
-                    local currentPeer = self.playerToPeer[playerId]
-                    if currentPeer and currentPeer ~= event.peer then
-                        Log.info("Player", playerId, "is still active on another peer, not removing from server")
-                        -- Just unregister the disconnected peer, don't remove the player
-                        unregisterPeerForPlayer(self, nil, event.peer)
-                    else
-                        -- This is the only peer for this player, safe to remove
-                        self:handlePlayerLeave({ playerId = playerId }, event.peer)
-                    end
-                else
-                    unregisterPeerForPlayer(self, nil, event.peer)
-                end
+    local event = self.transport.service(self.enetServer, 0)
+    while event do
+        if event.type == "connect" then
+            self.peers[event.peer] = true
+            Log.info("Peer connected")
+        elseif event.type == "receive" then
+            local message = Messages.decode(event.data)
+            if message then
+                self:_handleMessage(event.peer, message)
             end
-            event = EnetTransport.service(self.enetServer, 0)
+        elseif event.type == "disconnect" then
+            self:_handleDisconnect(event.peer)
         end
-    end
 
-    self.lastCleanup = self.lastCleanup + dt
-    if self.lastCleanup >= self.cleanupInterval then
-        self:cleanupDisconnectedPlayers()
-        self.lastCleanup = 0
+        event = self.transport.service(self.enetServer, 0)
     end
 end
 
-function NetworkServer:handleMessage(message, peer)
-    local playerId = nil
-
-    if type(peer) == "table" and peer.from == "client" then
-        playerId = peer.message and peer.message.playerId or nil
+function NetworkServer:_handleMessage(peer, message)
+    if not message or type(message) ~= "table" then
+        return
     end
 
-    if playerId and self.players[playerId] then
-        self.players[playerId].lastSeen = currentTime()
-    end
-
-    if message.type == MESSAGE_TYPES.PLAYER_JOIN then
-        self:handlePlayerJoin(message, peer)
-    elseif message.type == MESSAGE_TYPES.PLAYER_LEAVE then
-        self:handlePlayerLeave(message, peer)
-    elseif message.type == MESSAGE_TYPES.PLAYER_UPDATE then
-        self:handlePlayerUpdate(message, peer)
-    elseif message.type == MESSAGE_TYPES.PING then
-        self:handlePing(message, peer)
+    if message.type == TYPES.HELLO then
+        self:_handleHello(peer, message)
+    elseif message.type == TYPES.STATE then
+        self:_handleState(peer, message)
+    elseif message.type == TYPES.GOODBYE then
+        self:_handleDisconnect(peer)
     end
 end
 
-function NetworkServer:handlePlayerJoin(message, peer)
+function NetworkServer:_handleHello(peer, message)
     local playerId = self.nextPlayerId
     self.nextPlayerId = self.nextPlayerId + 1
 
-    local playerName = message.playerName or ("Player" .. playerId)
+    local name = message.name or string.format("Player %d", playerId)
 
-    local player = {
-        id = playerId,
-        name = playerName,
-        lastSeen = currentTime(),
-        data = message.data or {}
+    self.players[playerId] = {
+        playerId = playerId,
+        name = name,
+        state = sanitiseState(message.state or {}),
+        lastSeen = now()
     }
 
-    self.players[playerId] = player
-    registerPeerForPlayer(self, playerId, normalizePeer(self, peer))
+    self.peerToPlayer[peer] = playerId
 
-    -- Acknowledge the new player with their assigned ID and a view of current players.
-    self:sendToPeer(peer, {
-        type = MESSAGE_TYPES.PLAYER_JOIN,
+    local welcome = Messages.encode({
+        type = TYPES.WELCOME,
         playerId = playerId,
-        players = snapshotPlayers(self.players, playerId),
-        timestamp = currentTime()
-    }, true)
+        players = buildSnapshot(self.players)
+    })
+    self.transport.send({ peer = peer }, welcome, 0, true)
 
-    -- Notify other players about the newcomer.
-    self:broadcastToOthers(playerId, {
-        type = MESSAGE_TYPES.PLAYER_JOIN,
+    local broadcast = Messages.encode({
+        type = TYPES.STATE,
         playerId = playerId,
-        playerName = playerName,
-        data = player.data
+        state = self.players[playerId].state,
+        name = name
+    })
+    self:_broadcastExcept(peer, broadcast)
+
+    pushEvent(self, "joined", {
+        playerId = playerId,
+        name = name,
+        state = self.players[playerId].state
     })
 
-    Log.info("Player joined:", playerName, "(" .. playerId .. ")")
-    Log.info("Server now has", self:getPlayerCount(), "players total")
-    Events.emit("NETWORK_PLAYER_JOINED", { playerId = playerId, player = player })
+    Events.emit("NETWORK_PLAYER_JOINED", {
+        playerId = playerId,
+        playerName = name,
+        data = self.players[playerId].state
+    })
+
+    Log.info("Player", name, "joined with id", playerId)
 end
 
-function NetworkServer:handlePlayerLeave(message, peer)
-    local playerId = message.playerId
-
+function NetworkServer:_handleState(peer, message)
+    local playerId = canonicalPlayerId(message.playerId or self.peerToPlayer[peer])
     if not playerId or not self.players[playerId] then
-        unregisterPeerForPlayer(self, playerId, normalizePeer(self, peer))
+        return
+    end
+
+    self.players[playerId].state = sanitiseState(message.state or {})
+    self.players[playerId].lastSeen = now()
+
+    local encoded = Messages.encode({
+        type = TYPES.STATE,
+        playerId = playerId,
+        state = self.players[playerId].state,
+        name = self.players[playerId].name
+    })
+
+    self:_broadcastExcept(peer, encoded)
+
+    pushEvent(self, "state", {
+        playerId = playerId,
+        state = self.players[playerId].state,
+        name = self.players[playerId].name
+    })
+
+    Events.emit("NETWORK_PLAYER_UPDATED", {
+        playerId = playerId,
+        data = self.players[playerId].state,
+        playerName = self.players[playerId].name
+    })
+end
+
+function NetworkServer:_handleDisconnect(peer)
+    local playerId = self.peerToPlayer[peer]
+    if not playerId then
         return
     end
 
     local player = self.players[playerId]
     self.players[playerId] = nil
-    unregisterPeerForPlayer(self, playerId, normalizePeer(self, peer))
+    self.peerToPlayer[peer] = nil
+    self.peers[peer] = nil
 
-    self:broadcastToOthers(playerId, {
-        type = MESSAGE_TYPES.PLAYER_LEAVE,
+    local encoded = Messages.encode({
+        type = TYPES.GOODBYE,
+        playerId = playerId
+    })
+    self:_broadcastExcept(peer, encoded)
+
+    pushEvent(self, "left", { playerId = playerId })
+
+    Events.emit("NETWORK_PLAYER_LEFT", {
         playerId = playerId,
-        timestamp = currentTime()
+        playerName = player and player.name or nil
     })
 
-    Log.info("Player left:", player.name, "(" .. playerId .. ")")
-    Events.emit("NETWORK_PLAYER_LEFT", { playerId = playerId, player = player })
+    Log.info("Player", playerId, "disconnected")
 end
 
-function NetworkServer:handlePlayerUpdate(message, peer)
-    local playerId = message.playerId
-
-    if not playerId or not self.players[playerId] then
+function NetworkServer:_broadcastExcept(excludedPeer, data)
+    if not data then
         return
     end
 
-    local player = self.players[playerId]
-    registerPeerForPlayer(self, playerId, normalizePeer(self, peer))
-    player.data = message.data
-    player.lastSeen = currentTime()
-
-    local updatePayload = {
-        type = MESSAGE_TYPES.PLAYER_UPDATE,
-        playerId = playerId,
-        data = message.data,
-        timestamp = currentTime()
-    }
-
-    self:broadcastToOthers(playerId, updatePayload)
-
-    local snapshot = {}
-    if message.data then
-        for key, value in pairs(message.data) do
-            snapshot[key] = value
-        end
-    end
-    snapshot.playerId = snapshot.playerId or playerId
-    if player.name then
-        snapshot.playerName = snapshot.playerName or player.name
-    end
-
-    Events.emit("NETWORK_PLAYER_UPDATED", {
-        playerId = playerId,
-        data = snapshot
-    })
-end
-
-
-function NetworkServer:handlePing(message, peer)
-    local playerId = message.playerId
-    if playerId and self.players[playerId] then
-        self.players[playerId].lastSeen = currentTime()
-    end
-
-    self:sendToPeer(peer, {
-        type = MESSAGE_TYPES.PONG,
-        timestamp = message.timestamp
-    }, false)
-end
-
-
-function NetworkServer:sendToPeer(peer, message, reliable)
-    reliable = reliable ~= false
-
-    if self.transport == "enet" and self.enetServer then
-        local targetPeer = normalizePeer(self, peer)
-        if not targetPeer then
-            return false
-        end
-
-        local EnetTransport = require("src.core.network.transport.enet")
-        local json = require("src.libs.json")
-        local data = json.encode(message)
-        local success, err = EnetTransport.send({ peer = targetPeer }, data, 0, reliable)
-        if not success then
-            Log.warn("Failed to send message to peer:", err)
-            return false
-        end
-        return true
-    elseif self.transport == "file" and self.fileNetwork then
-        return self.fileNetwork:sendMessage(message)
-    end
-    return false
-end
-
-function NetworkServer:broadcast(message, reliable)
-    if self.transport == "enet" and self.enetServer then
-        self:broadcastToOthers(nil, message, reliable)
-    elseif self.transport == "file" and self.fileNetwork then
-        self.fileNetwork:sendMessage(message)
-    end
-end
-
-function NetworkServer:broadcastToOthers(excludePlayerId, message, reliable)
-    reliable = reliable ~= false
-
-    if self.transport == "enet" and self.enetServer then
-        local EnetTransport = require("src.core.network.transport.enet")
-        local json = require("src.libs.json")
-        local data = json.encode(message)
-
-        for peer in pairs(self.connectedPeers) do
-            local playerId = self.peerToPlayerId[peer]
-            if not excludePlayerId or playerId ~= excludePlayerId then
-                local success, err = EnetTransport.send({ peer = peer }, data, 0, reliable)
-                if not success then
-                    Log.warn("Failed to send message to peer:", err)
-                end
+    for peer in pairs(self.peers) do
+        if peer ~= excludedPeer then
+            local ok, err = self.transport.send({ peer = peer }, data, 0, true)
+            if not ok then
+                Log.warn("Failed to broadcast to peer:", err)
             end
-        end
-    end
-end
-
-function NetworkServer:cleanupDisconnectedPlayers()
-    local now = currentTime()
-    local timeout = 30.0
-
-    for playerId, player in pairs(self.players) do
-        if now - player.lastSeen > timeout then
-            Log.info("Cleaning up stale player:", player.name, "(" .. playerId .. ")")
-            self.players[playerId] = nil
-            unregisterPeerForPlayer(self, playerId)
-            self:broadcastToOthers(playerId, {
-                type = MESSAGE_TYPES.PLAYER_LEAVE,
-                playerId = playerId,
-                timestamp = now
-            })
-            Events.emit("NETWORK_PLAYER_LEFT", { playerId = playerId, player = player })
         end
     end
 end
@@ -437,61 +318,61 @@ end
 
 function NetworkServer:getPlayerCount()
     local count = 0
-    for playerId, player in pairs(self.players) do
+    for _ in pairs(self.players) do
         count = count + 1
     end
     return count
 end
 
-function NetworkServer:isRunning()
-    return self.isRunning
-end
-
-function NetworkServer:addHostPlayer(playerName, initialData)
-    if not self.isRunning then
-        return
-    end
-    
-    local hostPlayerId = 0  -- Host gets ID 0, clients get 1, 2, 3, etc.
-    local player = {
-        id = hostPlayerId,
-        name = playerName,
-        data = initialData or {},
-        lastSeen = currentTime()
-    }
-    
-    self.players[hostPlayerId] = player
-    Log.info("Added host player to server:", playerName, "ID:", hostPlayerId)
-end
-
-function NetworkServer:updateHostPlayer(playerData)
-    if not self.isRunning then
-        return
-    end
-    
-    -- Find the host player (ID 0)
-    local hostPlayerId = 0
-    if self.players[hostPlayerId] then
-        Log.info("Updating host player data for ID:", hostPlayerId)
-        self.players[hostPlayerId].data = playerData
-        self.players[hostPlayerId].lastSeen = currentTime()
-        
-        -- Broadcast the update to all clients
-        self:broadcastToOthers(hostPlayerId, {
-            type = MESSAGE_TYPES.PLAYER_UPDATE,
-            playerId = hostPlayerId,
-            data = playerData,
-            timestamp = currentTime()
-        })
-        
-        -- Also emit the event for local processing
-        Events.emit("NETWORK_PLAYER_UPDATED", {
-            playerId = hostPlayerId,
-            data = playerData
-        })
+function NetworkServer:updateHostState(state)
+    local hostId = 0
+    if not self.players[hostId] then
+        self.players[hostId] = {
+            playerId = hostId,
+            name = "Host",
+            state = sanitiseState(state),
+            lastSeen = now()
+        }
     else
-        Log.warn("Host player not found with ID:", hostPlayerId)
+        self.players[hostId].state = sanitiseState(state)
+        self.players[hostId].lastSeen = now()
     end
+
+    pushEvent(self, "state", {
+        playerId = hostId,
+        state = self.players[hostId].state,
+        name = self.players[hostId].name
+    })
+
+    local encoded = Messages.encode({
+        type = TYPES.STATE,
+        playerId = hostId,
+        state = self.players[hostId].state,
+        name = self.players[hostId].name
+    })
+    self:_broadcastExcept(nil, encoded)
+
+    Events.emit("NETWORK_PLAYER_UPDATED", {
+        playerId = hostId,
+        data = self.players[hostId].state,
+        playerName = self.players[hostId].name
+    })
+end
+
+function NetworkServer:addHostPlayer(name, state)
+    local hostId = 0
+    self.players[hostId] = {
+        playerId = hostId,
+        name = name or "Host",
+        state = sanitiseState(state),
+        lastSeen = now()
+    }
+
+    pushEvent(self, "state", {
+        playerId = hostId,
+        state = self.players[hostId].state,
+        name = self.players[hostId].name
+    })
 end
 
 return NetworkServer

--- a/src/systems/network_sync.lua
+++ b/src/systems/network_sync.lua
@@ -1,432 +1,200 @@
 --[[
-    Network Synchronization System
-    Handles sending and receiving player position updates in multiplayer
+    Network Synchronisation System
+    Bridges the multiplayer network layer with the entity world so that each
+    client can see other players moving around in real time.
 ]]
 
 local Events = require("src.core.events")
 local Log = require("src.core.log")
-local json = require("src.libs.json")
 
 local NetworkSync = {}
 
-local storeRemoteSnapshot
-local updateRemotePlayer
-local createRemotePlayer
-local getLocalPlayerCanonicalId
+local POSITION_SEND_INTERVAL = 1 / 15
 
-local resolvePlayerSnapshot
+local remoteEntities = {}
+local lastSentSnapshot = nil
+local sendAccumulator = 0
 
--- Remote players storage
-local remotePlayers = {}
-local remotePlayerSnapshots = {}
-local lastSentPosition = { x = 0, y = 0, angle = 0 }
-local positionUpdateTimer = 0
-local POSITION_UPDATE_INTERVAL = 1/30 -- 30 times per second
-
-local function canonicalizePlayerId(playerId)
-    if playerId == nil then
-        return nil
-    end
-    if type(playerId) == "string" then
-        return playerId
-    end
-    if type(playerId) == "number" then
-        return tostring(playerId)
-    end
-    return tostring(playerId)
+function NetworkSync.reset()
+    remoteEntities = {}
+    lastSentSnapshot = nil
+    sendAccumulator = 0
 end
 
-local function normalizePlayerDataId(data, fallbackId)
-    if type(data) == "table" then
-        if data.playerId ~= nil then
-            return canonicalizePlayerId(data.playerId)
-        end
-        if data.data and data.data.playerId ~= nil then
-            return canonicalizePlayerId(data.data.playerId)
-        end
-    end
-    return canonicalizePlayerId(fallbackId)
-end
-
-local function mergeSnapshotFields(target, source)
-    if type(target) ~= "table" or type(source) ~= "table" then
-        return target
+local function sanitiseSnapshot(snapshot)
+    if type(snapshot) ~= "table" then
+        return {
+            position = { x = 0, y = 0, angle = 0 },
+            velocity = { x = 0, y = 0 }
+        }
     end
 
-    if target == source then
-        return target
-    end
-
-    for key, value in pairs(source) do
-        if value ~= nil then
-            if type(value) == "table" then
-                local existing = target[key]
-                if type(existing) ~= "table" then
-                    existing = {}
-                end
-                if existing ~= value then
-                    mergeSnapshotFields(existing, value)
-                end
-                target[key] = existing
-            else
-                target[key] = value
-            end
-        end
-    end
-
-    return target
-end
-
--- Function definitions
-storeRemoteSnapshot = function(playerId, data)
-    local canonicalId = canonicalizePlayerId(playerId)
-    if not canonicalId then return nil end
-
-    local snapshot = remotePlayerSnapshots[canonicalId]
-    if not snapshot then
-        snapshot = { playerId = canonicalId }
-        remotePlayerSnapshots[canonicalId] = snapshot
-    end
-
-    if not data then
-        return snapshot
-    end
-
-    local payload = data
-    if type(payload) == "table" and type(payload.data) == "table" then
-        payload = payload.data
-    end
-
-    if type(payload) == "table" then
-        mergeSnapshotFields(snapshot, payload)
-    end
-
-    if type(data) == "table" then
-        if data.playerId ~= nil then
-            snapshot.playerId = canonicalizePlayerId(data.playerId) or snapshot.playerId or canonicalId
-        elseif type(payload) == "table" and payload.playerId ~= nil then
-            snapshot.playerId = canonicalizePlayerId(payload.playerId) or snapshot.playerId or canonicalId
-        else
-            snapshot.playerId = snapshot.playerId or canonicalId
-        end
-
-        if data.playerName ~= nil then
-            snapshot.playerName = data.playerName
-        elseif type(payload) == "table" and payload.playerName ~= nil then
-            snapshot.playerName = payload.playerName
-        end
-    end
-
-    remotePlayerSnapshots[canonicalId] = snapshot
-    return snapshot
-end
-
-updateRemotePlayer = function(playerId, data, world)
-    if not world then return end
-
-    local canonicalId = canonicalizePlayerId(playerId)
-    if not canonicalId then return end
-
-    storeRemoteSnapshot(playerId, data)
-
-    local remotePlayer = remotePlayers[canonicalId]
-
-    if remotePlayer and data.playerName and remotePlayer.playerName ~= data.playerName then
-        remotePlayer.playerName = data.playerName
-    end
-
-    -- Create remote player if it doesn't exist
-    if not remotePlayer then
-        Log.info("Creating remote player:", playerId)
-        remotePlayer = createRemotePlayer(canonicalId, data, world)
-        if remotePlayer then
-            remotePlayers[canonicalId] = remotePlayer
-        end
-        return
-    end
-
-    -- Update existing remote player
-    if remotePlayer.components and remotePlayer.components.position and data.position then
-        -- Smooth position interpolation
-        local pos = remotePlayer.components.position
-        local targetPos = data.position
-
-        -- Simple linear interpolation for smooth movement
-        pos.x = pos.x + (targetPos.x - pos.x) * 0.3
-        pos.y = pos.y + (targetPos.y - pos.y) * 0.3
-        pos.angle = targetPos.angle or 0
-
-        -- Keep physics body in sync with interpolated position so the
-        -- physics system doesn't snap us back to the old body position on
-        -- the next frame.
-        if remotePlayer.components.physics and remotePlayer.components.physics.body then
-            local body = remotePlayer.components.physics.body
-
-            if body.setPosition then
-                body:setPosition(pos.x, pos.y)
-            else
-                body.x = pos.x
-                body.y = pos.y
-            end
-
-            body.angle = pos.angle or body.angle or 0
-        end
-
-        -- Update velocity if available
-        if remotePlayer.components.velocity and data.velocity then
-            remotePlayer.components.velocity.x = data.velocity.x
-            remotePlayer.components.velocity.y = data.velocity.y
-        end
-
-        -- Mirror velocity on the physics body to avoid thruster artefacts
-        if data.velocity and remotePlayer.components.physics and remotePlayer.components.physics.body then
-            local body = remotePlayer.components.physics.body
-            if body.setVelocity then
-                body:setVelocity(data.velocity.x or 0, data.velocity.y or 0)
-            else
-                body.vx = data.velocity.x or 0
-                body.vy = data.velocity.y or 0
-            end
-        end
-
-        -- Update health if available
-        if remotePlayer.components.health and data.health then
-            local health = remotePlayer.components.health
-            health.hp = data.health.hp
-            health.maxHP = data.health.maxHp
-            health.shield = data.health.shield
-            health.maxShield = data.health.maxShield
-        end
-    end
-end
-
-createRemotePlayer = function(playerId, data, world)
-    local EntityFactory = require("src.templates.entity_factory")
-
-    local canonicalId = canonicalizePlayerId(playerId)
-
-    -- Create a basic ship for the remote player
-    local x = data.position and data.position.x or 0
-    local y = data.position and data.position.y or 0
-
-    local remotePlayer = EntityFactory.create("ship", "starter_frigate_basic", x, y)
-    if not remotePlayer then
-        Log.error("Failed to create remote player entity")
-        return nil
-    end
-
-    -- Mark as remote player
-    remotePlayer.isRemotePlayer = true
-    remotePlayer.remotePlayerId = data.playerId or canonicalId
-    remotePlayer.remotePlayerKey = canonicalId
-    remotePlayer.playerName = data.playerName or ("Player " .. playerId)
-
-    -- Set initial position
-    if data.position then
-        remotePlayer.components.position.x = data.position.x
-        remotePlayer.components.position.y = data.position.y
-        remotePlayer.components.position.angle = data.position.angle or 0
-    end
-
-    -- Set initial velocity
-    if data.velocity and remotePlayer.components.velocity then
-        remotePlayer.components.velocity.x = data.velocity.x
-        remotePlayer.components.velocity.y = data.velocity.y
-    end
-
-    -- Set initial health
-    if data.health and remotePlayer.components.health then
-        local health = remotePlayer.components.health
-        health.hp = data.health.hp
-        health.maxHP = data.health.maxHp
-        health.shield = data.health.shield
-        health.maxShield = data.health.maxShield
-    end
-
-    -- Add to world
-    world:addEntity(remotePlayer)
-    
-    Log.info("Created remote player:", playerId, "at", x, y, "isRemotePlayer:", remotePlayer.isRemotePlayer)
-    return remotePlayer
-end
-
-getLocalPlayerCanonicalId = function(networkManager)
-    if not networkManager then
-        return nil
-    end
-
-    if networkManager:isHost() then
-        return canonicalizePlayerId(0)
-    end
-
-    if networkManager.client and networkManager.client.playerId then
-        return canonicalizePlayerId(networkManager.client.playerId)
-    end
-
-    return nil
-end
-
-resolvePlayerSnapshot = function(playerId, playerData)
-    local canonicalId = canonicalizePlayerId(playerId)
-
-    if not canonicalId then
-        canonicalId = normalizePlayerDataId(playerData, playerId)
-    end
-
-    if not canonicalId then
-        return nil
-    end
-
-    local snapshot = nil
-
-    if playerData ~= nil then
-        snapshot = storeRemoteSnapshot(canonicalId, playerData)
-    else
-        snapshot = remotePlayerSnapshots[canonicalId]
-    end
-
-    if not snapshot then
-        return nil
-    end
+    local position = snapshot.position or {}
+    local velocity = snapshot.velocity or {}
 
     return {
-        playerId = canonicalId,
-        data = snapshot
+        position = {
+            x = tonumber(position.x) or 0,
+            y = tonumber(position.y) or 0,
+            angle = tonumber(position.angle) or 0
+        },
+        velocity = {
+            x = tonumber(velocity.x) or 0,
+            y = tonumber(velocity.y) or 0
+        }
     }
 end
 
--- Listen for incoming player updates
-Events.on("NETWORK_PLAYER_UPDATED", function(data)
-    Log.info("NETWORK_PLAYER_UPDATED received:", data and data.playerId or "nil")
-    if not data or not data.playerId then
+local function snapshotsDiffer(a, b)
+    if not a or not b then
+        return true
+    end
+
+    local posA, posB = a.position or {}, b.position or {}
+    local velA, velB = a.velocity or {}, b.velocity or {}
+
+    local posDelta = math.abs((posA.x or 0) - (posB.x or 0)) + math.abs((posA.y or 0) - (posB.y or 0))
+    local angleDelta = math.abs((posA.angle or 0) - (posB.angle or 0))
+    local velDelta = math.abs((velA.x or 0) - (velB.x or 0)) + math.abs((velA.y or 0) - (velB.y or 0))
+
+    return posDelta > 1 or angleDelta > 0.01 or velDelta > 0.5
+end
+
+local function ensureRemoteEntity(playerId, playerData, world)
+    if not world then
+        return nil
+    end
+
+    local entity = remoteEntities[playerId]
+    if entity then
+        return entity
+    end
+
+    local EntityFactory = require("src.templates.entity_factory")
+    local x = playerData.position and playerData.position.x or 0
+    local y = playerData.position and playerData.position.y or 0
+
+    entity = EntityFactory.create("ship", "starter_frigate_basic", x, y)
+    if not entity then
+        Log.error("Failed to spawn remote entity for player", playerId)
+        return nil
+    end
+
+    entity.isRemotePlayer = true
+    entity.remotePlayerId = playerId
+    entity.playerName = playerData.playerName or string.format("Player %s", tostring(playerId))
+
+    world:addEntity(entity)
+    remoteEntities[playerId] = entity
+
+    return entity
+end
+
+local function updateEntityFromSnapshot(entity, snapshot)
+    if not entity or not snapshot then
         return
     end
 
-    local resolved = resolvePlayerSnapshot(data.playerId, data)
+    local data = sanitiseSnapshot(snapshot)
 
-    if resolved and resolved.data and resolved.data.position then
-        local world = require("src.game").world
-        if world then
-            updateRemotePlayer(resolved.playerId, resolved.data, world)
+    if entity.components and entity.components.position then
+        entity.components.position.x = data.position.x
+        entity.components.position.y = data.position.y
+        entity.components.position.angle = data.position.angle
+    end
+
+    if entity.components and entity.components.velocity then
+        entity.components.velocity.x = data.velocity.x
+        entity.components.velocity.y = data.velocity.y
+    end
+
+    if entity.components and entity.components.physics and entity.components.physics.body then
+        local body = entity.components.physics.body
+        if body.setPosition then
+            body:setPosition(data.position.x, data.position.y)
+        else
+            body.x = data.position.x
+            body.y = data.position.y
         end
+        if body.setVelocity then
+            body:setVelocity(data.velocity.x, data.velocity.y)
+        else
+            body.vx = data.velocity.x
+            body.vy = data.velocity.y
+        end
+        body.angle = data.position.angle
+    end
+end
+
+local function removeRemoteEntity(world, playerId)
+    local entity = remoteEntities[playerId]
+    if not entity then
+        return
+    end
+
+    if world then
+        world:removeEntity(entity)
+    end
+
+    remoteEntities[playerId] = nil
+end
+
+Events.on("NETWORK_PLAYER_LEFT", function(payload)
+    local playerId = payload and payload.playerId
+    if playerId then
+        removeRemoteEntity(require("src.game").world, playerId)
     end
 end)
 
+Events.on("NETWORK_DISCONNECTED", function()
+    NetworkSync.reset()
+end)
+
+Events.on("NETWORK_SERVER_STOPPED", function()
+    NetworkSync.reset()
+end)
+
 function NetworkSync.update(dt, player, world, networkManager)
-    if not networkManager then
-        return
-    end
-    
-    if not networkManager:isMultiplayer() then
+    if not networkManager or not networkManager:isMultiplayer() then
         return
     end
 
-    -- Update position send timer
-    positionUpdateTimer = positionUpdateTimer + dt
+    sendAccumulator = sendAccumulator + (dt or 0)
 
-
-    -- Send player position updates
     if player and player.components and player.components.position then
-        local pos = player.components.position
-        local currentPos = { x = pos.x, y = pos.y, angle = pos.angle or 0 }
-        
-        -- Check if position has changed significantly or enough time has passed
-        local dx = currentPos.x - lastSentPosition.x
-        local dy = currentPos.y - lastSentPosition.y
-        local distance = math.sqrt(dx * dx + dy * dy)
-        
-        if distance > 2 or positionUpdateTimer >= POSITION_UPDATE_INTERVAL then
-            -- Send position update using the existing event system
-            local updateData = {
-                position = currentPos,
-                velocity = player.components.velocity and {
-                    x = player.components.velocity.x or 0,
-                    y = player.components.velocity.y or 0
-                } or { x = 0, y = 0 },
-                health = player.components.health and {
-                    hp = player.components.health.hp or 100,
-                    maxHp = player.components.health.maxHP or 100,
-                    shield = player.components.health.shield or 0,
-                    maxShield = player.components.health.maxShield or 0
-                } or nil
-            }
-            Log.info("Sending position update:", json.encode(updateData))
-            Events.emit("NETWORK_SEND_PLAYER_UPDATE", updateData)
-            
-            lastSentPosition = currentPos
-            positionUpdateTimer = 0
+        local position = player.components.position
+        local velocity = player.components.velocity
+
+        local snapshot = {
+            position = { x = position.x, y = position.y, angle = position.angle or 0 },
+            velocity = velocity and { x = velocity.x or 0, y = velocity.y or 0 } or { x = 0, y = 0 }
+        }
+
+        if sendAccumulator >= POSITION_SEND_INTERVAL or snapshotsDiffer(snapshot, lastSentSnapshot) then
+            networkManager:sendPlayerUpdate(snapshot)
+            lastSentSnapshot = snapshot
+            sendAccumulator = 0
         end
-    else
-        Log.info("No player or position component available for position updates")
     end
 
-    -- Update remote players
-    local players = networkManager:getPlayers()
-    local playerCount = 0
-    for _ in pairs(players) do playerCount = playerCount + 1 end
-    Log.info("NetworkSync: Found", playerCount, "players from network manager")
+    local players = networkManager:getPlayers() or {}
+    local localId = networkManager.getLocalPlayerId and networkManager:getLocalPlayerId() or nil
 
-    local localCanonicalId = getLocalPlayerCanonicalId(networkManager)
-
-    for playerId, playerData in pairs(players) do
-        local canonicalId = normalizePlayerDataId(playerData, playerId)
-
-        if canonicalId and localCanonicalId and canonicalId == localCanonicalId then
-            Log.info("Skipping local player from remote sync:", canonicalId)
-
-            -- Ensure we remove any stale remote entity or snapshot that may have been created for the local player
-            if remotePlayers[canonicalId] then
-                Log.info("Removing stale local remote player entity:", canonicalId)
-                if world then
-                    world:removeEntity(remotePlayers[canonicalId])
-                end
-                remotePlayers[canonicalId] = nil
-            end
-            remotePlayerSnapshots[canonicalId] = nil
-        else
-            if canonicalId then
-                local resolved = resolvePlayerSnapshot(canonicalId, playerData)
-                Log.info("Processing player:", canonicalId, "has position:", resolved and resolved.data and resolved.data.position ~= nil)
-                Log.info("Player data structure:", json.encode(playerData))
-
-                if resolved and resolved.data and resolved.data.position then
-                    updateRemotePlayer(resolved.playerId, resolved.data, world)
-                end
+    for id, playerInfo in pairs(players) do
+        if id ~= localId then
+            local entity = ensureRemoteEntity(id, playerInfo.state or {}, world)
+            if entity then
+                entity.playerName = playerInfo.playerName or entity.playerName
+                updateEntityFromSnapshot(entity, playerInfo.state)
             end
         end
     end
 
-    -- Clean up disconnected remote players
-    for playerId, remotePlayer in pairs(remotePlayers) do
-        local stillConnected = false
-        for id, playerData in pairs(players) do
-            if normalizePlayerDataId(playerData, id) == playerId then
-                stillConnected = true
-                break
-            end
-        end
-
-        if not stillConnected then
-            Log.info("Removing disconnected remote player:", playerId)
-            if world then
-                world:removeEntity(remotePlayer)
-            end
-            remotePlayers[playerId] = nil
-            remotePlayerSnapshots[playerId] = nil
+    for id, entity in pairs(remoteEntities) do
+        if not players[id] or id == localId then
+            removeRemoteEntity(world, id)
         end
     end
-end
-
-function NetworkSync.getRemotePlayers()
-    return remotePlayers
-end
-
-function NetworkSync.getRemotePlayer(playerId)
-    return remotePlayers[canonicalizePlayerId(playerId)]
-end
-
-function NetworkSync.getRemotePlayerSnapshots()
-    return remotePlayerSnapshots
 end
 
 return NetworkSync


### PR DESCRIPTION
## Summary
- replace the ad-hoc multiplayer protocol with a focused message layer for player state mirroring
- rebuild the host, client, and manager flow to broadcast normalised snapshots for remote players
- simplify the network sync system so the world spawns and updates remote ships from replicated movement data

## Testing
- Not run (Love2D runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e2269871b483229641a973436d12ac