### PR TITLE
Add host world snapshot replication to multiplayer clients

### DIFF
--- a/src/core/network/messages.lua
+++ b/src/core/network/messages.lua
@@ -6,7 +6,8 @@ Messages.TYPES = {
     STATE = "state",
     GOODBYE = "goodbye",
     PING = "ping",
-    PONG = "pong"
+    PONG = "pong",
+    WORLD_SNAPSHOT = "world_snapshot"
 }
 
 function Messages.encode(payload)


### PR DESCRIPTION
## Summary
- add a world snapshot message type and broadcast sanitized snapshots from the server
- teach the client and manager to track world snapshots and clean up when sessions end
- update game boot to rebuild the world from snapshots for clients and to broadcast the host state

## Testing
- not run (lua tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e22d9f2cc883229015fd020233ffb5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a WORLD_SNAPSHOT message and plumbing so the host sanitizes/broadcasts world snapshots, clients rebuild/track the world from them, and only the host spawns world entities.
> 
> - **Networking**:
>   - **Protocol**: Add `TYPES.WORLD_SNAPSHOT` in `src/core/network/messages.lua`.
>   - **Server (`src/core/network/server.lua`)**:
>     - Sanitize/store `worldSnapshot`; include in `WELCOME`; broadcast on updates via `updateWorldSnapshot`; emit `NETWORK_WORLD_SNAPSHOT`; reset on start/stop.
>   - **Client (`src/core/network/client.lua`)**:
>     - Sanitize/track `worldSnapshot`; expose `getWorldSnapshot`; handle snapshots in `WELCOME` and `WORLD_SNAPSHOT`; clear on disconnect.
>   - **Manager (`src/core/network/manager.lua`)**:
>     - Track `_worldSnapshot`; listen/emit `NETWORK_WORLD_SNAPSHOT`; add `updateWorldSnapshot` and `getWorldSnapshot`; clear on session end; handle server `world_snapshot` events.
> - **Game (`src/game.lua`)**:
>   - Clients: rebuild world from received snapshots (spawn/clear synced entities); queue until world ready; clear on disconnect/server stop.
>   - Host: build snapshots from live world and broadcast; send on server start and after player spawn.
>   - Authority: only host creates stations/objects and runs `SpawningSystem`; clients do not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b94a058a8ff101ba3343b7ef401978521253302. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->