### PR TITLE
Avoid Zeroing World Snapshots

### DIFF
--- a/src/core/network/client.lua
+++ b/src/core/network/client.lua
@@ -118,11 +118,20 @@ local function sanitiseWorldSnapshot(snapshot)
         return nil
     end
 
+    local width = tonumber(snapshot.width)
+    local height = tonumber(snapshot.height)
+
     local sanitised = {
-        width = tonumber(snapshot.width) or 0,
-        height = tonumber(snapshot.height) or 0,
         entities = {}
     }
+
+    if width ~= nil then
+        sanitised.width = width
+    end
+
+    if height ~= nil then
+        sanitised.height = height
+    end
 
     if type(snapshot.entities) == "table" then
         for _, entry in ipairs(snapshot.entities) do

--- a/src/core/network/server.lua
+++ b/src/core/network/server.lua
@@ -129,11 +129,20 @@ local function sanitiseWorldSnapshot(snapshot)
         return nil
     end
 
+    local width = tonumber(snapshot.width)
+    local height = tonumber(snapshot.height)
+
     local sanitised = {
-        width = tonumber(snapshot.width) or 0,
-        height = tonumber(snapshot.height) or 0,
         entities = {}
     }
+
+    if width ~= nil then
+        sanitised.width = width
+    end
+
+    if height ~= nil then
+        sanitised.height = height
+    end
 
     if type(snapshot.entities) == "table" then
         for _, entry in ipairs(snapshot.entities) do


### PR DESCRIPTION
## Summary
- avoid defaulting sanitised world snapshot dimensions to zero on the server so clients keep the host world size
- mirror the sanitisation change on the client to preserve received dimensions only when present

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e24462ef7c83228ed99c5e12c9a758