### PR TITLE
Handle enemy update messages on clients

### DIFF
--- a/src/core/network/client.lua
+++ b/src/core/network/client.lua
@@ -383,6 +383,12 @@ function NetworkClient:_handleMessage(message)
             self.worldSnapshot = snapshot
             Events.emit("NETWORK_WORLD_SNAPSHOT", { snapshot = snapshot })
         end
+    elseif message.type == TYPES.ENEMY_UPDATE then
+        -- Forward enemy replication payloads to gameplay systems
+        local enemies = type(message.enemies) == "table" and message.enemies or nil
+        if enemies then
+            Events.emit("NETWORK_ENEMY_UPDATE", { enemies = enemies })
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
- emit NETWORK_ENEMY_UPDATE events when the client receives enemy replication payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e24e07b7508322b62796658ad216cc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle `TYPES.ENEMY_UPDATE` on the client and emit `NETWORK_ENEMY_UPDATE` with the validated `enemies` payload.
> 
> - **Network Client (`src/core/network/client.lua`)**:
>   - Handle `TYPES.ENEMY_UPDATE` messages.
>   - Validate `message.enemies` as a table and emit `NETWORK_ENEMY_UPDATE` with `{ enemies }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05112550988cef9ac36000e5f186fbe01293a34c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->