### PR TITLE
Add LAN hosting toggle for existing single-player worlds

### DIFF
--- a/src/core/action_map.lua
+++ b/src/core/action_map.lua
@@ -260,44 +260,25 @@ ActionMap.registerAction({
         print("F3 KEY PRESSED!")
         Log.info("F3 key pressed - attempting to toggle multiplayer hosting")
         print("Current state - isMultiplayer:", Game.isMultiplayer(), "isHost:", Game.isHost())
-        
-        local networkManager = Game.getNetworkManager()
-        if not networkManager then
-            Log.error("Network manager not available")
-            Notifications.add("Network manager not available", "error")
-            return false
-        end
-        
-        Log.info("Network manager found, isMultiplayer:", networkManager:isMultiplayer(), "isHost:", networkManager:isHost())
-        
-        if networkManager:isMultiplayer() then
-            if networkManager:isHost() then
-                -- Stop hosting
-                Log.info("Stopping host")
-                networkManager:leaveGame()
-                Game.setMultiplayerMode(false, false)
-                Notifications.add("Stopped hosting multiplayer game", "info")
+
+        local success, result = Game.toggleLanHosting()
+        if not success then
+            if result == "no_network" then
+                Notifications.add("Network manager not available", "error")
             else
-                -- Leave client mode
-                Log.info("Leaving client mode")
-                networkManager:leaveGame()
-                Game.setMultiplayerMode(false, false)
-                Notifications.add("Left multiplayer game", "info")
-            end
-        else
-            -- Start hosting and switch to multiplayer mode
-            Log.info("Starting host and switching to multiplayer mode")
-            if networkManager:startHost() then
-                Game.setMultiplayerMode(true, true)
-                print("After setMultiplayerMode - isMultiplayer:", Game.isMultiplayer(), "isHost:", Game.isHost())
-                Log.info("Host started successfully, game is now in multiplayer mode")
-                Notifications.add("Started hosting multiplayer game (F3 to stop)", "success")
-            else
-                Log.error("Failed to start host")
                 Notifications.add("Failed to start multiplayer server", "error")
             end
+            return false
         end
-        
+
+        if result == "lan_opened" then
+            Notifications.add("Opened current world to LAN players (F3 to close)", "success")
+        elseif result == "lan_closed" then
+            Notifications.add("Stopped hosting multiplayer game", "info")
+        else
+            Notifications.add("Left multiplayer game", "info")
+        end
+
         return true
     end,
 })

--- a/src/core/network/manager.lua
+++ b/src/core/network/manager.lua
@@ -32,6 +32,7 @@ function NetworkManager.new()
     self._players = {}
     self._localPlayerId = nil
     self._worldSnapshot = nil
+    self._pendingWorldSnapshot = nil
 
     self:setupEventListeners()
 
@@ -141,6 +142,10 @@ function NetworkManager:startHost(port)
         }
     }
 
+    if self._pendingWorldSnapshot then
+        self.server:updateWorldSnapshot(self._pendingWorldSnapshot)
+    end
+
     Events.emit("NETWORK_PLAYER_JOINED", {
         playerId = 0,
         playerName = hostName,
@@ -244,6 +249,12 @@ function NetworkManager:update(dt)
 end
 
 function NetworkManager:updateWorldSnapshot(snapshot, peer)
+    if snapshot ~= nil then
+        self._pendingWorldSnapshot = Util.deepCopy(snapshot)
+    else
+        self._pendingWorldSnapshot = nil
+    end
+
     if not self._isHost or not self.server then
         return
     end


### PR DESCRIPTION
## Summary
- capture the current single-player world state before opening to LAN hosting
- add a Game.toggleLanHosting helper and use it from the F3 action to mirror an "open to LAN" flow
- keep pending world snapshots inside the network manager so newly opened hosts reuse existing entities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e250fb909883229b3fbae7cdd617ac

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Game.toggleLanHosting to open/close current single-player world to LAN and refactor F3 action to use it, with NetworkManager holding a pending world snapshot for new hosts.
> 
> - **Gameplay/Core**:
>   - Add `Game.toggleLanHosting()` and `Game.captureWorldSnapshotForLan()` to open/close the current single-player world to LAN, capturing and broadcasting a world snapshot.
>   - On host start, set multiplayer mode and send snapshot (or fallback to `broadcastHostWorldSnapshot`).
> - **Networking**:
>   - `NetworkManager` stores `_pendingWorldSnapshot`; when hosting starts, applies it via `server:updateWorldSnapshot`.
>   - `updateWorldSnapshot` now caches the snapshot even before hosting; deep-copies to avoid mutation.
> - **Input/Actions**:
>   - Replace manual F3 networking logic in `src/core/action_map.lua` with `Game.toggleLanHosting()`; show contextual notifications for `lan_opened`, `lan_closed`, `client_left`, and errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce643837fafa823034885a41aa1ebe27c4fe7d6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->