### PR TITLE
Fix hub spawn lookup for sanitised world snapshots

### DIFF
--- a/src/core/network/server.lua
+++ b/src/core/network/server.lua
@@ -584,10 +584,21 @@ function NetworkServer:_generateSpawnPosition()
     -- Try to get hub position from world snapshot if available
     if self.worldSnapshot and self.worldSnapshot.entities then
         for _, entity in ipairs(self.worldSnapshot.entities) do
-            if entity.type == "hub_station" and entity.position then
-                hubX = entity.position.x
-                hubY = entity.position.y
-                break
+            local kind = entity.kind or entity.type
+            if kind == "hub_station" then
+                local x = entity.x
+                local y = entity.y
+
+                if not (type(x) == "number" and type(y) == "number") and entity.position then
+                    x = entity.position.x
+                    y = entity.position.y
+                end
+
+                if type(x) == "number" and type(y) == "number" then
+                    hubX = x
+                    hubY = y
+                    break
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- update the network server spawn helper to understand sanitised world snapshots
- fall back to legacy position data when available to keep backwards compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e285df7a8c83228d9fe8430e6d2c6c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update spawn position logic to read hub coordinates from sanitised snapshots (kind/x,y) with fallback to legacy entity.position.
> 
> - **Network server (`src/core/network/server.lua`)**:
>   - Update `_generateSpawnPosition` to detect hub via `entity.kind` (fallback to `entity.type`) and read coordinates from `entity.x`/`entity.y`.
>   - Fallback to legacy `entity.position.x`/`y` when `x`/`y` are absent or invalid.
>   - Guard with numeric checks before applying hub coordinates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4c60cd8dec36908c91133ba44267d260932bb7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->