### PR TITLE
Handle Position Tables In World Snapshot

### DIFF
--- a/src/core/network/server.lua
+++ b/src/core/network/server.lua
@@ -111,6 +111,14 @@ local function sanitiseWorldEntry(entry)
 
     local x = tonumber(entry.x)
     local y = tonumber(entry.y)
+    local angle = entry.angle
+
+    if (not x or not y) and type(entry.position) == "table" then
+        x = tonumber(entry.position.x) or x
+        y = tonumber(entry.position.y) or y
+        angle = angle ~= nil and angle or entry.position.angle
+    end
+
     if not x or not y then
         return nil
     end
@@ -122,8 +130,8 @@ local function sanitiseWorldEntry(entry)
         y = y
     }
 
-    if entry.angle ~= nil then
-        sanitised.angle = tonumber(entry.angle) or 0
+    if angle ~= nil then
+        sanitised.angle = tonumber(angle) or 0
     end
 
     local extra = sanitiseWorldExtras(entry.extra)
@@ -584,10 +592,21 @@ function NetworkServer:_generateSpawnPosition()
     -- Try to get hub position from world snapshot if available
     if self.worldSnapshot and self.worldSnapshot.entities then
         for _, entity in ipairs(self.worldSnapshot.entities) do
-            if entity.type == "hub_station" and entity.position then
-                hubX = entity.position.x
-                hubY = entity.position.y
-                break
+            local kind = entity.kind or entity.type
+            if kind == "hub_station" then
+                local x = entity.x
+                local y = entity.y
+
+                if not (type(x) == "number" and type(y) == "number") and entity.position then
+                    x = entity.position.x
+                    y = entity.position.y
+                end
+
+                if type(x) == "number" and type(y) == "number" then
+                    hubX = x
+                    hubY = y
+                    break
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- accept hub entities that provide coordinates under a nested position table when sanitising world snapshots
- preserve the reported angle from nested position data so downstream systems keep their orientation information

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e285df7a8c83228d9fe8430e6d2c6c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Accepts nested position x/y/angle in world snapshots and improves hub_station detection for spawn generation.
> 
> - **World Snapshot Sanitization (`src/core/network/server.lua`)**:
>   - Accept `position.x`/`position.y` when top-level `x`/`y` missing; preserve `angle` from top-level or `position.angle`.
> - **Spawn Logic (`_generateSpawnPosition`)**:
>   - Detect hub via `kind` or `type` equals `hub_station`.
>   - Read hub coordinates from top-level `x`/`y` or fallback to `position.x`/`position.y`, with numeric validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0266608e1e15e0b05244d49484f2539e14de3ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->