### PR TITLE
Restore client spawn fallback to pending network state

### DIFF
--- a/src/core/network/session.lua
+++ b/src/core/network/session.lua
@@ -702,4 +702,8 @@ function Session.getHub()
     return state.hub
 end
 
+function Session.getPendingSelfNetworkState()
+    return state.pendingSelfNetworkState
+end
+
 return Session

--- a/src/game.lua
+++ b/src/game.lua
@@ -559,6 +559,13 @@ function Game.load(fromSave, saveSlot, loadingScreen, multiplayer, isHost)
         end
       end
 
+      if not assignedPosition then
+        local pendingState = NetworkSession.getPendingSelfNetworkState and NetworkSession.getPendingSelfNetworkState()
+        if pendingState and pendingState.position then
+          assignedPosition = pendingState.position
+        end
+      end
+
       if assignedPosition then
         -- Use the position assigned by the server
         px = assignedPosition.x or Constants.SPAWNING.MARGIN


### PR DESCRIPTION
## Summary
- expose the pending self network state from the session module
- allow clients to reuse the pending state when the network manager has not populated an assigned position yet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2a08731fc832289f23d85241ed334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Session.getPendingSelfNetworkState and uses it during client spawn to fall back to the pending assigned position when the manager state isn’t ready.
> 
> - **Networking/Spawn**:
>   - **Session**: Add `Session.getPendingSelfNetworkState()` accessor to expose `pendingSelfNetworkState`.
>   - **Client spawn logic (`src/game.lua`)**: Fallback to `NetworkSession.getPendingSelfNetworkState().position` when no assigned position is available from `networkManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 942f495c0401f90fcd7621da25e218dcf3fc90af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->