### PR TITLE
Fix network client connection error handling

### DIFF
--- a/src/core/network/client.lua
+++ b/src/core/network/client.lua
@@ -256,6 +256,9 @@ function NetworkClient:connect(address, port)
         return true
     end
 
+    -- Reset any stale error state before attempting to connect again
+    self.lastError = nil
+
     local ok, EnetTransport = pcall(require, "src.core.network.transport.enet")
     if not ok or not EnetTransport or not EnetTransport.isAvailable() then
         self.lastError = "ENet transport not available"
@@ -294,15 +297,15 @@ function NetworkClient:connect(address, port)
             else
                 lastError = result
                 self.lastError = result
-                EnetTransport.disconnectClient(client)
                 EnetTransport.destroy(client)
             end
         end
     end
 
     if not connectedClient then
-        self.lastError = lastError or self.lastError or "Connection failed"
-        return false, self.lastError
+        local finalError = lastError or "Connection failed"
+        self.lastError = finalError
+        return false, finalError
     end
 
     self.transport = EnetTransport


### PR DESCRIPTION
## Summary
- reset the client connection error state before starting new connection attempts and ensure failures report the latest message
- avoid calling disconnectClient on unsuccessful attempts to prevent disconnecting half-initialised peers

## Testing
- not run (reason: no automated tests available)


------
https://chatgpt.com/codex/tasks/task_b_68e2a21d314083228190ff2e9129a12c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reset `lastError` before connecting, avoid `disconnectClient` on failed attempts, and return the explicit final error message on failure.
> 
> - **Network client (`src/core/network/client.lua`)**:
>   - `NetworkClient:connect`:
>     - Reset `self.lastError` before starting connection attempts.
>     - Remove `EnetTransport.disconnectClient(client)` on unsuccessful attempts; only destroy the client.
>     - On overall failure, return and store a clear final error (`lastError` or "Connection failed") instead of reusing a stale value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ac4268858427fd273af841f96718834d6369d5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->