### PR TITLE
Sync Clients To Host Enemy Entities

### DIFF
--- a/src/core/network/session.lua
+++ b/src/core/network/session.lua
@@ -185,6 +185,9 @@ local function applyWorldSnapshot(snapshot)
         local entity = spawnEntityFromSnapshot(entry)
         if entity then
             entity.isSyncedEntity = true
+            if entry.id ~= nil then
+                entity.syncedHostId = tostring(entry.id)
+            end
             world:addEntity(entity)
             if entry.kind == "station" and entry.id == "hub_station" then
                 state.hub = entity


### PR DESCRIPTION
## Summary
- tag host-synced entities with their network id when applying world snapshots
- reuse host-spawned enemy entities on clients and queue pending snapshots until they exist
- clear pending remote enemy state when enemies despawn to prevent duplicate ghosts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2d07be9b08322a44a25c8e731b9aa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Syncs player thruster state (for engine trails), tags world entities with host IDs, and reworks remote enemy syncing to reuse host entities with queued updates and smoother motion/cleanup.
> 
> - **Enemy Sync (client)**:
>   - Rework `ensureRemoteEnemy` to match existing host-spawned enemies via `syncedHostId`/IDs; stop creating local fallbacks.
>   - Queue `pendingEnemySnapshots` until entities exist; apply once resolved; clear on despawn.
>   - Add smoother interpolation with start/target positions, smoothstep timing, velocity targets, and initial physics alignment.
> - **Player Networking**:
>   - Include `thrusterState` in snapshots; sanitize and diff with thresholds; trigger sends on change.
>   - Drive remote engine trails from `thrusterState` (thrusting/intensity, position updates).
> - **World Snapshot Application**:
>   - Tag synced entities with `syncedHostId = tostring(entry.id)` to enable reliable matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b23ecbcd334ad46edd306f70df5c5d5bd0718ae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->