### PR TITLE
Remove Damage Numbers And Refresh Overhead Bars

### DIFF
--- a/src/systems/collision/effects.lua
+++ b/src/systems/collision/effects.lua
@@ -179,10 +179,6 @@ function CollisionEffects.applyDamage(entity, damageValue, source)
         remainingDamage = incoming - shieldDamage
     end
 
-    if shieldDamage > 0 then
-        Effects.addDamageNumber(entity.components.position.x, entity.components.position.y, math.floor(shieldDamage), "shield")
-    end
-
     local newShield = math.max(0, shieldBefore - shieldDamage)
     if newShield ~= shieldBefore then
         health.shield = newShield
@@ -192,7 +188,6 @@ function CollisionEffects.applyDamage(entity, damageValue, source)
     end
 
     if remainingDamage > 0 then
-        Effects.addDamageNumber(entity.components.position.x, entity.components.position.y, math.floor(remainingDamage), "hull")
         health.hp = math.max(0, (health.hp or 0) - remainingDamage)
     end
 
@@ -205,9 +200,13 @@ function CollisionEffects.applyDamage(entity, damageValue, source)
         hadShield = hadShield or (shieldDamage > 0),
         source = source
     }
-    -- Mark recently damaged by player for enemy HUD bars
-    if source and (source.isPlayer or (source.components and source.components.player ~= nil)) then
-        entity._hudDamageTime = love.timer.getTime()
+    -- Mark recently damaged for overhead bars
+    if shieldDamage > 0 or remainingDamage > 0 then
+        if love and love.timer and love.timer.getTime then
+            entity._hudDamageTime = love.timer.getTime()
+        else
+            entity._hudDamageTime = os.clock()
+        end
     end
 
     if entity.isPlayer then

--- a/src/systems/network_sync.lua
+++ b/src/systems/network_sync.lua
@@ -192,19 +192,12 @@ local function updateEntityFromSnapshot(entity, snapshot)
         health.energy = data.health.energy
         health.maxEnergy = data.health.maxEnergy
 
-        -- Detect health changes and create damage numbers for remote players
-        if entity.isRemotePlayer and entity.components.position then
-            local shieldDamage = math.max(0, (oldShield or 0) - (health.shield or 0))
-            local hullDamage = math.max(0, (oldHP or 0) - (health.hp or 0))
-            
-            if shieldDamage > 0 or hullDamage > 0 then
-                local Effects = require("src.systems.effects")
-                if shieldDamage > 0 then
-                    Effects.addDamageNumber(entity.components.position.x, entity.components.position.y, math.floor(shieldDamage), "shield")
-                end
-                if hullDamage > 0 then
-                    Effects.addDamageNumber(entity.components.position.x, entity.components.position.y, math.floor(hullDamage), "hull")
-                end
+        -- Detect health changes for remote players and show overhead bars
+        if entity.isRemotePlayer and (health.shield ~= oldShield or health.hp ~= oldHP) then
+            if love and love.timer and love.timer.getTime then
+                entity._hudDamageTime = love.timer.getTime()
+            else
+                entity._hudDamageTime = os.clock()
             end
         end
 

--- a/src/systems/turret/beam_weapons.lua
+++ b/src/systems/turret/beam_weapons.lua
@@ -242,9 +242,6 @@ function BeamWeapons.applyLaserDamage(target, damage, source, skillId, damageMet
     -- Apply shield damage
     if shieldDamage > 0 then
         health.shield = math.max(0, shieldBefore - shieldDamage)
-        -- Add damage number effect
-        local Effects = require("src.systems.effects")
-        Effects.addDamageNumber(target.components.position.x, target.components.position.y, math.floor(shieldDamage), "shield")
     end
 
     -- Apply hull damage
@@ -252,10 +249,6 @@ function BeamWeapons.applyLaserDamage(target, damage, source, skillId, damageMet
     if hullDamage > 0 then
         health.hp = math.max(0, (health.hp or 0) - hullDamage)
         hullDamageApplied = true
-        -- Add damage number effect
-        local Effects = require("src.systems.effects")
-        Effects.addDamageNumber(target.components.position.x, target.components.position.y, math.floor(hullDamage), "hull")
-        
         if health.hp <= 0 then
             target.dead = true
             target._killedBy = source


### PR DESCRIPTION
## Summary
- remove the damage-number data structures and rendering path from the shared effects system
- ensure collision, beam, and network-sync damage flows only update HUD timers when damage is dealt
- redraw above-head entity bars with a larger LoL-style combined hull/shield treatment for clearer feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e2d6f684148322af57f915ab401048