### PR TITLE
Normalize Beam Damage Across Network

### DIFF
--- a/src/systems/turret/beam_weapons.lua
+++ b/src/systems/turret/beam_weapons.lua
@@ -6,10 +6,10 @@ local TargetUtils = require("src.core.target_utils")
 local BeamWeapons = {}
 
 -- Helper function to send beam weapon fire request to host
-local function sendBeamWeaponFireRequest(turret, sx, sy, angle, beamLength, damageConfig)
+local function sendBeamWeaponFireRequest(turret, sx, sy, angle, beamLength, damageConfig, deltaTime)
     local NetworkSession = require("src.core.network.session")
     local networkManager = NetworkSession.getManager()
-    
+
     if networkManager and networkManager:isMultiplayer() and not networkManager:isHost() then
         -- Client: send beam weapon fire request to host
         local request = {
@@ -19,6 +19,7 @@ local function sendBeamWeaponFireRequest(turret, sx, sy, angle, beamLength, dama
             angle = angle,
             beamLength = beamLength,
             damageConfig = damageConfig,
+            deltaTime = deltaTime,
             ownerId = turret.owner and turret.owner.id or nil
         }
         
@@ -106,13 +107,20 @@ function BeamWeapons.updateLaserTurret(turret, dt, target, locked, world)
         damageConfig = {
             min = turret.damage_range.min,
             max = turret.damage_range.max,
-            skill = turret.skillId
+            skill = turret.skillId,
+            damagePerSecond = turret.damagePerSecond
         }
     else
-        damageConfig = { min = 1, max = 2, skill = turret.skillId }
+        damageConfig = {
+            min = 1,
+            max = 2,
+            value = turret.damagePerSecond or 1,
+            skill = turret.skillId,
+            damagePerSecond = turret.damagePerSecond
+        }
     end
     
-    local requestSent = sendBeamWeaponFireRequest(turret, sx, sy, angle, beamLength, damageConfig)
+    local requestSent = sendBeamWeaponFireRequest(turret, sx, sy, angle, beamLength, damageConfig, dt)
     
     -- If not a client or request failed, process beam locally (for host)
     if not requestSent then


### PR DESCRIPTION
## Summary
- include the beam firing delta time and damage-per-second data when clients request laser shots
- use the transmitted firing window on the host to compute beam damage so players deal consistent damage regardless of who fires

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2e191e6648322b05dd0a0f381ea7a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clients now send beam deltaTime and DPS; host computes laser damage from these values with a clamped duration and enriched damage metadata.
> 
> - **Networking/Host (`src/core/network/session.lua`)**:
>   - Use `request.damageConfig.damagePerSecond` when available; fall back to min/max or value.
>   - Compute beam duration from `request.deltaTime` (clamped to 0–0.25) instead of fixed value; derive `damageAmount` accordingly.
>   - Build richer `damageMeta` (includes `min`, `max`, `value`, `skill`, `damagePerSecond`).
> - **Client/Turret (`src/systems/turret/beam_weapons.lua`)**:
>   - Extend `sendBeamWeaponFireRequest` to accept and include `deltaTime`.
>   - Include `damagePerSecond` (and fallback `value`) in `damageConfig` sent to host.
>   - Pass `dt` when sending beam fire requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d76eff415faee488130aed5f12fadb8bcc9a697c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->