### PR TITLE
Ensure Multiplayer Projectile Source Metadata Sync

### DIFF
--- a/src/core/network/session.lua
+++ b/src/core/network/session.lua
@@ -512,14 +512,41 @@ local function handleProjectileRequest(request, playerId)
     end
 
     local projectileId = request.projectileId or "gun_bullet"
+    local turretSlot = request.turretSlot
+    local turretId = request.turretId
+    local turretType = request.turretType
+    local sourcePlayerId = request.playerId or player.remotePlayerId or playerId
+    local sourceShipId = request.shipId or player.shipId or (player.ship and player.ship.id) or nil
+
+    local turretInstance = nil
+    if player.getTurretInSlot and turretSlot then
+        turretInstance = player:getTurretInSlot(turretSlot)
+    end
+
+    local projectileKind = "bullet"
+    if request.kind then
+        projectileKind = request.kind
+    elseif turretInstance and turretInstance.kind then
+        projectileKind = turretInstance.kind
+    end
+
     local extraConfig = {
         angle = request.angle or 0,
         friendly = true,
         damage = request.damageConfig,
-        kind = "bullet",
+        kind = projectileKind,
         additionalEffects = request.additionalEffects,
         source = player,
+        sourcePlayerId = sourcePlayerId,
+        sourceShipId = sourceShipId,
+        sourceTurretSlot = turretSlot,
+        sourceTurretId = turretId,
+        sourceTurretType = turretType,
     }
+
+    if turretInstance and turretInstance.impact and extraConfig.additionalEffects == nil then
+        extraConfig.impact = turretInstance.impact
+    end
 
 
     local projectile = EntityFactory.create(

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -22,6 +22,7 @@ function Player.new(x, y, shipId)
   -- Set the metatable to this Player object to add player-specific methods.
   local self = setmetatable(ship, Player)
   self.ship = shipConfig -- Store the ship's definition data
+  self.shipId = shipId or "starter_frigate_basic"
   self.isPlayer = true -- Ensure this flag is set.
     if not self.components.physics then
         self.components.physics = require("src.components.physics").new({

--- a/src/game/projectiles.lua
+++ b/src/game/projectiles.lua
@@ -31,6 +31,11 @@ function Projectiles.spawn(x, y, angle, friendly, opts)
         length = opts.length,
         timed_life = opts.timed_life,
         additionalEffects = opts.additionalEffects,
+        sourcePlayerId = opts.sourcePlayerId,
+        sourceShipId = opts.sourceShipId,
+        sourceTurretSlot = opts.sourceTurretSlot,
+        sourceTurretId = opts.sourceTurretId,
+        sourceTurretType = opts.sourceTurretType,
     }
     extra_config.source = opts.source
 

--- a/src/systems/network_sync.lua
+++ b/src/systems/network_sync.lua
@@ -160,6 +160,7 @@ local function ensureRemoteEntity(playerId, playerData, world)
     entity.isRemotePlayer = true
     entity.remotePlayerId = playerId
     entity.playerName = playerData.playerName or string.format("Player %s", tostring(playerId))
+    entity.shipId = playerData.shipId or entity.shipId or "starter_frigate_basic"
     
     -- Ensure remote players have the player component for proper collision detection
     if not entity.components.player then

--- a/src/templates/entity_factory.lua
+++ b/src/templates/entity_factory.lua
@@ -112,6 +112,7 @@ function EntityFactory.createPlayer(shipId, x, y)
   local config = {
     isPlayer = true,
     energyRegen = 20, -- units per second
+    shipId = shipId,
   }
   return EntityFactory.create("ship", shipId, x, y, config)
 end

--- a/src/templates/projectile.lua
+++ b/src/templates/projectile.lua
@@ -27,9 +27,14 @@ function Projectile.new(x, y, angle, friendly, config)
     local vy = math.sin(angle) * speed
 
     self.components = {
-        bullet = { 
+        bullet = {
             source = config.source, -- Track shooter to avoid self-hit
-            impact = config.impact  -- Pass impact effects for collision visuals
+            impact = config.impact,  -- Pass impact effects for collision visuals
+            slot = config.sourceTurretSlot,
+            turretId = config.sourceTurretId,
+            turretType = config.sourceTurretType,
+            sourcePlayerId = config.sourcePlayerId,
+            sourceShipId = config.sourceShipId,
         },
         position = Position.new({ x = x, y = y, angle = angle }),
         velocity = Velocity.new({ x = vx, y = vy }),


### PR DESCRIPTION
## Summary
- track player, ship, and turret metadata when firing projectiles and sending weapon fire requests
- propagate projectile source details through multiplayer snapshots and remote projectile updates
- persist ship identifiers on player and remote entities to keep turret lookups consistent across peers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2e97466608322a5d3277384b86709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks and syncs projectile source (player/ship/turret) metadata end-to-end, using turret-derived kind/impact when spawning and mirroring via network snapshots.
> 
> - **Networking/Sync**:
>   - Include `sourcePlayerId`, `sourceShipId`, `sourceTurretSlot`, `sourceTurretId`, `sourceTurretType` in projectile snapshots and apply/update paths (`src/systems/remote_projectile_sync.lua`).
>   - Ensure remote entities carry `shipId` and attach to projectiles; infer missing `sourcePlayerId`/`sourceShipId` from source entities.
> - **Projectile Spawning/Handling**:
>   - When handling weapon fire requests (`src/core/network/session.lua`), resolve turret instance, derive `projectileKind`, apply turret `impact` if absent, and set source metadata on `extraConfig`.
>   - Pass source metadata through `Projectiles.spawn` and `EntityFactory.create` to projectile templates.
>   - Store source metadata on `components.bullet` in `src/templates/projectile.lua`.
> - **Turrets**:
>   - Add metadata builder and include source fields in client fire requests and host-side spawns (`src/systems/turret/projectile_weapons.lua`).
> - **Entities**:
>   - Persist `shipId` on player and remote player entities; set via `EntityFactory.createPlayer` and in `network_sync.ensureRemoteEntity`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0e0da686dbc4fe9892f6dcc404a62bd6aec39a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->