### PR TITLE
Ensure escape menu blur canvas resizes with viewport

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -66,6 +66,13 @@ function Game.resize(w, h)
     if State.world then
         State.world:resize(w, h)
     end
+
+    if Game.blurCanvas then
+        if Game.blurCanvas.release then
+            Game.blurCanvas:release()
+        end
+        Game.blurCanvas = nil
+    end
 end
 
 function Game.draw()

--- a/src/game/draw.lua
+++ b/src/game/draw.lua
@@ -46,9 +46,20 @@ function Draw.draw(Game)
     QuestLogHUD.draw(player)
 
     if UIManager.isOpen("escape") then
+        local viewportWidth, viewportHeight = Viewport.getDimensions()
+
+        if Game.blurCanvas then
+            local canvasWidth, canvasHeight = Game.blurCanvas:getDimensions()
+            if canvasWidth ~= viewportWidth or canvasHeight ~= viewportHeight then
+                if Game.blurCanvas.release then
+                    Game.blurCanvas:release()
+                end
+                Game.blurCanvas = nil
+            end
+        end
+
         if not Game.blurCanvas then
-            local w, h = Viewport.getDimensions()
-            Game.blurCanvas = love.graphics.newCanvas(w, h)
+            Game.blurCanvas = love.graphics.newCanvas(viewportWidth, viewportHeight)
         end
 
         local currentCanvas = love.graphics.getCanvas()


### PR DESCRIPTION
## Summary
- validate the escape menu blur canvas matches the current viewport size before drawing
- recreate the blur canvas when dimensions change and release outdated canvases
- clear the cached blur canvas during window resize so the next draw uses the correct size

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68e3c5e99bc88322a45f2202a52f998d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the escape menu blur canvas matches the current viewport by recreating on size changes and clearing it on window resize.
> 
> - **Rendering/UI**:
>   - **Escape menu blur**:
>     - In `src/game/draw.lua`, validate `Game.blurCanvas` dimensions against `Viewport.getDimensions()`; release and recreate when mismatched; reuse current viewport width/height for creation; draw unchanged.
>     - In `src/game.lua`, on `Game.resize`, release and clear `Game.blurCanvas` so next draw recreates it at the correct size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acf17c273a11252da21a4aba587194fc13d19b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->