### PR TITLE
Remove Bounty System References

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A 2D space exploration game built with LÖVE2D featuring mining, combat, trading
 - **E**: Interact with stations and objects
 - **Tab**: Open inventory
 - **I**: Open skills menu
-- **B**: Open bounty/missions menu
 - **ESC**: Pause menu
 
 ### Gameplay Loop

--- a/content/ships/basic_drone.lua
+++ b/content/ships/basic_drone.lua
@@ -66,7 +66,6 @@ return {
         }
     },
 
-    bounty = 8,
     xpReward = 10,
     cargo = { capacity = 20, volumeLimit = 8.0 }, -- 8 m^3 cargo hold for basic drone
 
@@ -102,20 +101,17 @@ return {
         basic = {
             name = "Basic Patrol Drone",
             ai = { intelligenceLevel = "BASIC", aggressiveType = "neutral" },
-            bounty = 6,
             xpReward = 8
         },
         guard = {
-            name = "Guard Drone", 
+            name = "Guard Drone",
             ai = { intelligenceLevel = "STANDARD", aggressiveType = "aggressive" },
-            bounty = 12,
             xpReward = 15,
             hull = { hp = 80, shield = 50, cap = 0 } -- No energy system
         },
         elite = {
             name = "Elite Hunter Drone",
             ai = { intelligenceLevel = "ELITE", aggressiveType = "hostile" },
-            bounty = 20,
             xpReward = 25,
             hull = { hp = 120, shield = 80, cap = 0 }, -- No energy system
             engine = { maxSpeed = 400, accel = 650 }
@@ -123,7 +119,6 @@ return {
         ace = {
             name = "Ace Combat Drone",
             ai = { intelligenceLevel = "ACE", aggressiveType = "hostile" },
-            bounty = 35,
             xpReward = 40,
             hull = { hp = 180, shield = 120, cap = 0 }, -- No energy system
             engine = { maxSpeed = 420, accel = 700 },

--- a/content/ships/boss_drone.lua
+++ b/content/ships/boss_drone.lua
@@ -77,7 +77,6 @@ return {
     }
   },
 
-  bounty = 60,
   xpReward = 100,
   cargo = { capacity = 50, volumeLimit = 25.0 }, -- 25 m^3 cargo hold for boss drone
 

--- a/docs/SYSTEMS_GUIDE.md
+++ b/docs/SYSTEMS_GUIDE.md
@@ -73,7 +73,7 @@ UI elements (`StatusBars`, `SkillXpPopup`, `Theme` animations) are updated befor
 
 ### Destruction System (`src/systems/destruction.lua`)
 * Processes `entity.dead` flags, spawns wreckage/pickups, and dispatches destruction events.
-* Notifies bounty tracking and quest systems about kills.
+* Emits kill events for quest systems and rewards experience gains.
 
 ## Gameplay Systems
 

--- a/src/content/normalizer.lua
+++ b/src/content/normalizer.lua
@@ -80,7 +80,6 @@ function Normalizer.normalizeShip(def)
   if def.variants then
     out.variants = deepCopy(def.variants)
   end
-  if def.bounty ~= nil then out.bounty = def.bounty end
   if def.xpReward ~= nil then out.xpReward = def.xpReward end
   if def.energyRegen ~= nil or def.energy_regen ~= nil then
     out.energyRegen = def.energyRegen or def.energy_regen

--- a/src/core/input.lua
+++ b/src/core/input.lua
@@ -248,7 +248,6 @@ function Input.update(dt)
     
     if mainState.UIManager then
         if mainState.UIManager.isOpen("inventory")
-            or mainState.UIManager.isOpen("bounty")
             or mainState.UIManager.isOpen("skills")
             or mainState.UIManager.isOpen("escape")
             or mainState.UIManager.isModalActive() then
@@ -324,8 +323,6 @@ function Input.love_keypressed(key)
               mainState.UIManager.close("ship")
             elseif component == "map" then
               mainState.UIManager.close("map")
-            elseif component == "bounty" then
-              mainState.UIManager.close("bounty")
             elseif component == "skills" then
               mainState.UIManager.close("skills")
             elseif component == "settings" then
@@ -564,17 +561,6 @@ function Input.mousereleased(x, y, button)
     if SkillsPanel.isVisible() then
         local consumed, shouldClose = SkillsPanel.mousereleased(x, y, button)
         if shouldClose then SkillsPanel.visible = false end
-        if consumed then return end
-    end
-
-    if mainState.UIManager.isOpen("bounty") then
-        local Bounty = require("src.ui.bounty")
-        local docking = gameState.player and gameState.player.components and gameState.player.components.docking_status
-        local consumed, shouldClose = Bounty.mousereleased(x, y, button, docking and docking.docked, function()
-            gameState.player:addGC(gameState.bounty.uncollected or 0)
-            gameState.bounty.uncollected = 0
-        end)
-        if shouldClose then mainState.UIManager.close("bounty") end
         if consumed then return end
     end
 

--- a/src/systems/destruction.lua
+++ b/src/systems/destruction.lua
@@ -1,7 +1,6 @@
 local Effects = require("src.systems.effects")
 local Wreckage = require("src.entities.wreckage")
 local ItemPickup = require("src.entities.item_pickup")
-local Pickups = require("src.systems.pickups")
 local Events = require("src.core.events")
 local Content = require("src.content.content")
 local ProceduralGen = require("src.core.procedural_gen")
@@ -12,34 +11,6 @@ local DestructionSystem = {}
 
 local Log = require("src.core.log")
 local Debug = require("src.core.debug")
-
--- Add bounty rewards to uncollected bounties
-local function addBountyReward(gameState, enemy, enemyName)
-  if not gameState or not gameState.bounty then return end
-  
-  local bountyValue = enemy.bounty or 0
-  local xpValue = enemy.xpReward or 0
-  
-  if bountyValue > 0 or xpValue > 0 then
-    gameState.bounty.uncollected = (gameState.bounty.uncollected or 0) + bountyValue
-    
-    -- Add entry to recent kills
-    if not gameState.bounty.entries then
-      gameState.bounty.entries = {}
-    end
-    
-    table.insert(gameState.bounty.entries, {
-      name = enemyName or "Unknown Enemy",
-      gc = bountyValue,
-      timestamp = love.timer.getTime()
-    })
-    
-    -- Keep only last 10 entries
-    while #gameState.bounty.entries > 10 do
-      table.remove(gameState.bounty.entries, 1)
-    end
-  end
-end
 
 local function rollLoot(drops)
   local items = {}
@@ -221,10 +192,7 @@ function DestructionSystem.update(world, gameState, hub)
         if isEnemyShip then
           -- Only give rewards if not killed by unfriendly station
           if not e._killedByUnfriendlyStation then
-            -- Enemy death: add bounty rewards and use configured loot table
-            local enemyName = e.name or "Unknown Enemy"
-            addBountyReward(gameState, e, enemyName)
-
+            -- Enemy death: grant XP to the player and use configured loot table
             -- Grant XP to the player
             local players = world:get_entities_with_components("player")
             if players and #players > 0 and e.xpReward then

--- a/src/templates/enemy.lua
+++ b/src/templates/enemy.lua
@@ -10,7 +10,6 @@ function Enemy.new(x, y, options)
     self.sig = 80
     self.aggro = false
     self.name = "Scout Drone"
-    self.bounty = 8
     self.xpReward = 10
     self.dead = false
 

--- a/src/templates/entity_factory.lua
+++ b/src/templates/entity_factory.lua
@@ -135,9 +135,6 @@ function EntityFactory.createEnemy(shipId, x, y)
     config.isEnemy = true
     config.shipId = shipId -- Store ship ID for quest tracking
 
-    if config.bounty == nil then
-        config.bounty = enemySettings.bounty or (shipConfig and shipConfig.bounty) or 25
-    end
     if config.xpReward == nil then
         config.xpReward = enemySettings.xpReward or (shipConfig and shipConfig.xpReward) or 50
     end
@@ -264,7 +261,6 @@ function EntityFactory.createFreighter(shipId, x, y)
     local shipConfig = Content.getShip(shipId)
     local config = {
         isFreighter = true,
-        bounty = (shipConfig and shipConfig.bounty) or 100, -- Higher bounty for valuable cargo
         xpReward = (shipConfig and shipConfig.xpReward) or 200,
     }
     return EntityFactory.create("ship", shipId, x, y, config)

--- a/src/templates/ship.lua
+++ b/src/templates/ship.lua
@@ -220,7 +220,6 @@ function Ship.new(x, y, angle, friendly, shipConfig)
   self.target = nil
   self.moveTarget = nil
   self.dead = false
-  self.bounty = extraConfig.bounty or 0
   self.xpReward = extraConfig.xpReward or 0
   
   -- Apply extra config properties (like shipId, isEnemy flags, etc.)


### PR DESCRIPTION
## Summary
- strip the defunct bounty UI handling and reward tracking code paths
- remove bounty fields from ship content and normalizer helpers now that payouts are gone
- update player-facing docs to reflect the absence of a bounty menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3c8602ecc83228f61dbc86b0f7f4d