### PR TITLE
Add Beam Energy Hysteresis To Turrets

### DIFF
--- a/docs/CONTENT_GUIDE.md
+++ b/docs/CONTENT_GUIDE.md
@@ -62,6 +62,8 @@ Ships are player and AI-controlled vessels.
 - `projectile`: Embedded projectile definition
 - `damage_range`: Min/max damage values
 - `cycle`: Firing rate
+- `energyPerSecond`: Continuous energy draw for beam weapons
+- `minResumeEnergy` / `resumeEnergyMultiplier`: Optional reserve threshold that beams must reach before reactivating after an energy stall
 - `optimal`/`falloff`: Range parameters
 - `maxHeat`/`heatPerShot`: Overheating system
 

--- a/src/systems/turret/core.lua
+++ b/src/systems/turret/core.lua
@@ -31,6 +31,8 @@ function Turret.new(owner, params)
     self.cycle = params.cycle
     self.capCost = params.capCost
     self.energyPerSecond = params.energyPerSecond
+    self.minResumeEnergy = params.minResumeEnergy
+    self.resumeEnergyMultiplier = params.resumeEnergyMultiplier
 
     -- Targeting parameters
     self.optimal = params.optimal


### PR DESCRIPTION
## Summary
- add hysteresis-based energy checks to combat laser turrets so beams wait for a reserve before reactivating
- apply the same starvation handling to mining and salvaging beams, including sound shutdown while idle
- expose optional minResumeEnergy and resumeEnergyMultiplier turret parameters and document them for content designers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3c98753f883229ed599baeebdf632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements hysteresis-based energy handling for beam weapons (combat, mining, salvaging) with configurable resume thresholds and updates docs and turret params.
> 
> - **Beam energy handling**:
>   - **Combat laser** (`src/systems/turret/beam_weapons.lua`): Replace per-tick drain with hysteresis logic using `energyPerSecond`, `_energyStarved`, `minResumeEnergy`, and `resumeEnergyMultiplier`; cleanly disable beam state on starvation.
>   - **Utility beams** (`src/systems/turret/utility_beams.lua`): Apply same hysteresis to mining and salvaging beams; stop corresponding looped sounds when starved; maintain beam state vars.
> - **Turret core params** (`src/systems/turret/core.lua`): Accept new optional `minResumeEnergy` and `resumeEnergyMultiplier` alongside `energyPerSecond`.
> - **Docs** (`docs/CONTENT_GUIDE.md`): Document `energyPerSecond` and optional `minResumeEnergy`/`resumeEnergyMultiplier` for beam weapons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2a638ec264799f93b77aea64f15491d6fe49ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->