### PR TITLE
Replace reticle crosshair with sci-fi cursor

### DIFF
--- a/src/core/ui.lua
+++ b/src/core/ui.lua
@@ -250,7 +250,7 @@ function UI.drawHUD(player, world, enemies, hub, wreckage, lootDrops, camera, re
   -- Always hide system mouse cursor - use in-game cursors instead
   if love and love.mouse and love.mouse.setVisible then love.mouse.setVisible(false) end
 
-  -- Draw reticle when not over UI (in-game targeting cursor)
+  -- Draw targeting overlays and gameplay cursor when not over UI
   local UIManager = require("src.core.ui_manager")
   local overUI = UIManager.isMouseOverUI and UIManager.isMouseOverUI() or false
 

--- a/src/core/ui_manager.lua
+++ b/src/core/ui_manager.lua
@@ -10,6 +10,7 @@
 local Theme = require("src.core.theme")
 local Viewport = require("src.core.viewport")
 local Registry = require("src.ui.core.registry")
+local SciFiCursor = require("src.ui.hud.sci_fi_cursor")
 
 -- UI components
 local Inventory = require("src.ui.inventory")
@@ -579,7 +580,7 @@ function UIManager.draw(player, world, enemies, hub, wreckage, lootDrops)
   local TooltipManager = require("src.ui.tooltip_manager")
   TooltipManager.draw()
 
-  -- Draw UI cursor when mouse is over UI elements (on top of all UI)
+  -- Draw the sci-fi cursor when mouse is over UI elements (on top of all UI)
   local overUI = false
   for _, comp in ipairs(Registry.visibleSortedDescending()) do
     local r = comp.getRect and comp.getRect()
@@ -594,7 +595,6 @@ function UIManager.draw(player, world, enemies, hub, wreckage, lootDrops)
 
   if overUI then
     local mx, my = love.mouse.getPosition()
-    local Theme = require("src.core.theme")
     local Settings = require("src.core.settings")
 
     -- Get UI cursor color (similar to reticle)
@@ -606,11 +606,9 @@ function UIManager.draw(player, world, enemies, hub, wreckage, lootDrops)
       uiCursorColor = Theme.colors.accent
     end
 
-    Theme.setColor(uiCursorColor)
-    love.graphics.polygon("fill", mx, my, mx + 12, my + 12, mx, my + 15)
-    Theme.setColor(Theme.colors.text)
-    love.graphics.setLineWidth(1)
-    love.graphics.polygon("line", mx, my, mx + 12, my + 12, mx, my + 15)
+    local fill = Theme.withAlpha(uiCursorColor, 0.95)
+    local outline = Theme.withAlpha(Theme.colors.text, 0.85)
+    SciFiCursor.draw(mx, my, fill, outline)
   end
 
   -- Restore prior font to prevent persistent size changes across frames

--- a/src/ui/hud/sci_fi_cursor.lua
+++ b/src/ui/hud/sci_fi_cursor.lua
@@ -1,0 +1,31 @@
+local Theme = require("src.core.theme")
+
+local SciFiCursor = {}
+
+local function resolveColor(color, fallback)
+    if type(color) == "table" then
+        return color
+    end
+    return fallback
+end
+
+function SciFiCursor.drawAtOrigin(fillColor, outlineColor)
+    local fill = resolveColor(fillColor, Theme.colors.accent)
+    local outline = resolveColor(outlineColor, Theme.colors.text)
+
+    Theme.setColor(fill)
+    love.graphics.polygon("fill", 0, 0, 12, 12, 0, 15)
+
+    Theme.setColor(outline)
+    love.graphics.setLineWidth(1)
+    love.graphics.polygon("line", 0, 0, 12, 12, 0, 15)
+end
+
+function SciFiCursor.draw(x, y, fillColor, outlineColor)
+    love.graphics.push()
+    love.graphics.translate(x, y)
+    SciFiCursor.drawAtOrigin(fillColor, outlineColor)
+    love.graphics.pop()
+end
+
+return SciFiCursor

--- a/src/ui/settings_panel.lua
+++ b/src/ui/settings_panel.lua
@@ -6,6 +6,7 @@ local Window = require("src.ui.common.window")
 local Dropdown = require("src.ui.common.dropdown")
 local Strings = require("src.core.strings")
 local Util = require("src.core.util")
+local SciFiCursor = require("src.ui.hud.sci_fi_cursor")
 
 local SettingsPanel = {}
 
@@ -531,24 +532,27 @@ function SettingsPanel.drawContent(window, x, y, w, h)
     SettingsPanel._showFpsToggleRect = { x = showFpsToggleX, y = showFpsToggleY - scrollY, w = showFpsToggleW, h = showFpsToggleH }
     yOffset = yOffset + itemHeight
 
-    -- Reticle popup trigger, current preview, and color dropdown
+    -- Cursor popup trigger, current preview, and color dropdown
     Theme.setColor(Theme.colors.text)
-    love.graphics.print("Reticle:", labelX, yOffset)
+    love.graphics.print("Cursor:", labelX, yOffset)
     local btnX, btnY, btnW, btnH = valueX, yOffset - 4, 140, 26
     local btnHover = mx >= btnX and mx <= btnX + btnW and scrolledMouseY >= btnY and scrolledMouseY <= btnY + btnH
     -- Show full text without truncation
-    Theme.drawStyledButton(btnX, btnY, btnW, btnH, "Select Reticle", btnHover, love.timer.getTime())
+    Theme.drawStyledButton(btnX, btnY, btnW, btnH, "Select Cursor", btnHover, love.timer.getTime())
     SettingsPanel._reticleButtonRect = { x = btnX, y = btnY - scrollY, w = btnW, h = btnH }
     -- Preview next to button (same height as button)
     local previewSize = btnH
     local pvX, pvY = btnX + btnW + 10, btnY
     Theme.drawGradientGlowRect(pvX, pvY, previewSize, previewSize, 3, Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
-    local Reticle = require("src.ui.hud.reticle")
     love.graphics.push()
     love.graphics.translate(pvX + previewSize * 0.5, pvY + previewSize * 0.5)
-    Theme.setColor(Theme.colors.textHighlight)
-    local previewScale = (previewSize / 32) * 0.85 * 0.8
-    Reticle.drawPreset(currentGraphicsSettings.reticle_style or 1, previewScale, Theme.colors.textHighlight)
+    local styleIndex = math.max(1, math.min(50, currentGraphicsSettings.reticle_style or 1))
+    local pointerScale = 0.9 + (styleIndex - 1) / 49 * 0.6
+    local baseScale = (previewSize / 32) * 0.95
+    love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
+    local previewFill = Theme.withAlpha(Theme.colors.textHighlight, 0.95)
+    local previewOutline = Theme.withAlpha(Theme.colors.text, 0.85)
+    SciFiCursor.drawAtOrigin(previewFill, previewOutline)
     love.graphics.pop()
     yOffset = yOffset + itemHeight
 
@@ -876,9 +880,9 @@ function SettingsPanel.drawContent(window, x, y, w, h)
         love.graphics.setLineWidth(2)
         love.graphics.rectangle("line", previewX, previewY, previewSize, previewSize)
         
-        -- Draw "Reticle Color" label above preview
+        -- Draw "Cursor Color" label above preview
         Theme.setColor(Theme.colors.text)
-        local labelText = "Reticle Color"
+        local labelText = "Cursor Color"
         local labelW = Theme.fonts.small:getWidth(labelText)
         love.graphics.print(labelText, previewX + (previewSize - labelW) / 2, previewY - 20)
         
@@ -903,7 +907,6 @@ function SettingsPanel.drawContent(window, x, y, w, h)
         local cols, cell, gap = 10, 44, 8
         local total, rows = 50, math.ceil(50/cols)
         SettingsPanel._reticlePopup = { x = px, y = py, cols = cols, rows = rows, cell = cell, gap = gap }
-        local Reticle = require("src.ui.hud.reticle")
         local curStyle = currentGraphicsSettings.reticle_style or 1
         for i = 1, total do
             local r = math.floor((i-1)/cols)
@@ -914,10 +917,12 @@ function SettingsPanel.drawContent(window, x, y, w, h)
             Theme.drawGradientGlowRect(cx, cy, cell, cell, 3, isSel and Theme.colors.bg3 or Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
             love.graphics.push()
             love.graphics.translate(cx + cell * 0.5, cy + cell * 0.5)
-            -- Use selected color for previews
-            Theme.setColor({cr, cg, cb, 1})
-            local previewScale = 0.8 * (cell / 32) * 0.85
-            Reticle.drawPreset(i, previewScale, {cr, cg, cb, 1})
+            local pointerScale = 0.9 + (i - 1) / 49 * 0.6
+            local baseScale = (cell / 32) * 0.95
+            love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
+            local previewFill = {cr, cg, cb, 1}
+            local previewOutline = Theme.withAlpha(Theme.colors.text, 0.85)
+            SciFiCursor.drawAtOrigin(previewFill, previewOutline)
             love.graphics.pop()
         end
         -- Done button


### PR DESCRIPTION
## Summary
- replace the in-game reticle rendering with a shared sci-fi cursor module while preserving lock-on indicators
- reuse the new cursor when hovering UI and in the graphics settings previews so copy references the cursor instead of the reticle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e3ca65f6388322b2160d32ab5ac736

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the reticle’s on-screen pointer with a shared sci‑fi cursor module and reuses it for UI hover and settings previews, preserving lock-on indicators.
> 
> - **HUD/Gameplay**:
>   - Replace reticle’s drawn pointer with `SciFiCursor` in `src/ui/hud/reticle.lua` (keeps lock-on indicators/markers/warnings intact).
>   - Minor HUD comment tweak in `src/core/ui.lua`.
> - **UI Cursor**:
>   - Use `SciFiCursor` for UI hover cursor in `src/core/ui_manager.lua` with theme/setting-driven fill/outline.
> - **Settings**:
>   - Update labels from "Reticle" to "Cursor" where shown and preview the pointer using `SciFiCursor` in `src/ui/settings_panel.lua` (grid previews and button preview scaled by style index).
> - **New Module**:
>   - Add `src/ui/hud/sci_fi_cursor.lua` providing `draw`/`drawAtOrigin` helpers for a consistent cursor shape and themed colors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e044541ad415ed24642a296dcdbc302ca4e534b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->