### PR TITLE
Refactor settings panel into modular sections

### DIFF
--- a/src/ui/settings/audio_panel.lua
+++ b/src/ui/settings/audio_panel.lua
@@ -1,0 +1,139 @@
+local Theme = require("src.core.theme")
+
+local AudioPanel = {}
+
+local currentSettings
+local hovered = {
+    master_volume = false,
+    sfx_volume = false,
+    music_volume = false
+}
+
+local draggingSlider
+local sliderRects = {}
+
+function AudioPanel.setSettings(settings)
+    currentSettings = settings
+end
+
+local function sliderColor(isHovered)
+    if isHovered then
+        return Theme.colors.textHighlight, Theme.effects.glowWeak * 0.3
+    end
+    return Theme.colors.bg3, Theme.effects.glowWeak * 0.1
+end
+
+local function handleColor(isHovered)
+    if isHovered then
+        return Theme.colors.accentGold, Theme.effects.glowWeak * 0.4
+    end
+    return Theme.colors.accent, Theme.effects.glowWeak * 0.2
+end
+
+function AudioPanel.draw(layout)
+    local yOffset = layout.yOffset
+    local labelX = layout.labelX
+    local valueX = layout.valueX
+    local itemHeight = layout.itemHeight
+
+    Theme.setColor(Theme.colors.accent)
+    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
+    love.graphics.print("Audio Settings", labelX, yOffset)
+    love.graphics.setFont(layout.settingsFont)
+    yOffset = yOffset + 30
+
+    sliderRects = {}
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Master Volume:", labelX, yOffset)
+    local masterText = string.format("%.2f", currentSettings.master_volume)
+    love.graphics.print(masterText, layout.x + 400, yOffset)
+    local sliderX = valueX
+    local sliderW = 200
+    local sliderScreenY = yOffset - 5 - layout.scrollY
+    local trackColor, trackGlow = sliderColor(hovered.master_volume)
+    Theme.drawGradientGlowRect(sliderX, yOffset - 5, sliderW, 10, 2, trackColor, Theme.colors.bg2, Theme.colors.border, trackGlow)
+    local handleX = sliderX + (sliderW - 10) * currentSettings.master_volume
+    local handleColor, handleGlow = handleColor(hovered.master_volume)
+    Theme.drawGradientGlowRect(handleX, yOffset - 7.5, 10, 15, 2, handleColor, Theme.colors.bg3, Theme.colors.border, handleGlow)
+    sliderRects.master_volume = { x = sliderX, y = sliderScreenY, w = sliderW, h = 15 }
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("SFX Volume:", labelX, yOffset)
+    local sfxText = string.format("%.2f", currentSettings.sfx_volume)
+    love.graphics.print(sfxText, layout.x + 400, yOffset)
+    sliderScreenY = yOffset - 5 - layout.scrollY
+    trackColor, trackGlow = sliderColor(hovered.sfx_volume)
+    Theme.drawGradientGlowRect(sliderX, yOffset - 5, sliderW, 10, 2, trackColor, Theme.colors.bg2, Theme.colors.border, trackGlow)
+    handleX = sliderX + (sliderW - 10) * currentSettings.sfx_volume
+    handleColor, handleGlow = handleColor(hovered.sfx_volume)
+    Theme.drawGradientGlowRect(handleX, yOffset - 7.5, 10, 15, 2, handleColor, Theme.colors.bg3, Theme.colors.border, handleGlow)
+    sliderRects.sfx_volume = { x = sliderX, y = sliderScreenY, w = sliderW, h = 15 }
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Music Volume:", labelX, yOffset)
+    local musicText = string.format("%.2f", currentSettings.music_volume)
+    love.graphics.print(musicText, layout.x + 400, yOffset)
+    sliderScreenY = yOffset - 5 - layout.scrollY
+    trackColor, trackGlow = sliderColor(hovered.music_volume)
+    Theme.drawGradientGlowRect(sliderX, yOffset - 5, sliderW, 10, 2, trackColor, Theme.colors.bg2, Theme.colors.border, trackGlow)
+    handleX = sliderX + (sliderW - 10) * currentSettings.music_volume
+    handleColor, handleGlow = handleColor(hovered.music_volume)
+    Theme.drawGradientGlowRect(handleX, yOffset - 7.5, 10, 15, 2, handleColor, Theme.colors.bg3, Theme.colors.border, handleGlow)
+    sliderRects.music_volume = { x = sliderX, y = sliderScreenY, w = sliderW, h = 15 }
+    yOffset = yOffset + itemHeight
+
+    layout.yOffset = yOffset
+    return yOffset
+end
+
+function AudioPanel.mousepressed(x, y, button)
+    if button ~= 1 then return false end
+    for name, rect in pairs(sliderRects) do
+        if x >= rect.x and x <= rect.x + rect.w and y >= rect.y and y <= rect.y + rect.h then
+            draggingSlider = name
+            local pct = (x - rect.x) / rect.w
+            currentSettings[name] = math.max(0, math.min(1, pct))
+            return true
+        end
+    end
+    return false
+end
+
+function AudioPanel.mousereleased()
+    draggingSlider = nil
+end
+
+function AudioPanel.mousemoved(x, y)
+    for key in pairs(hovered) do hovered[key] = false end
+
+    for name, rect in pairs(sliderRects) do
+        if x >= rect.x and x <= rect.x + rect.w and y >= rect.y and y <= rect.y + rect.h then
+            hovered[name] = true
+        end
+    end
+
+    if draggingSlider then
+        local rect = sliderRects[draggingSlider]
+        if rect then
+            local pct = (x - rect.x) / rect.w
+            currentSettings[draggingSlider] = math.max(0, math.min(1, pct))
+            return true
+        end
+    end
+
+    return draggingSlider ~= nil
+end
+
+function AudioPanel.getContentHeight(baseY)
+    local yOffset = baseY
+    yOffset = yOffset + 30
+    yOffset = yOffset + 40
+    yOffset = yOffset + 40
+    yOffset = yOffset + 40
+    return yOffset
+end
+
+return AudioPanel

--- a/src/ui/settings/controls_panel.lua
+++ b/src/ui/settings/controls_panel.lua
@@ -1,0 +1,103 @@
+local Theme = require("src.core.theme")
+local Strings = require("src.core.strings")
+local Settings = require("src.core.settings")
+
+local ControlsPanel = {}
+
+local keymap = {}
+local bindingAction
+local buttonRects = {}
+local keymapChangedCallback
+
+local keybindOrder = {
+    "toggle_inventory", "toggle_ship", "toggle_skills",
+    "toggle_map",
+    "hotbar_1", "hotbar_2", "hotbar_3", "hotbar_4", "hotbar_5", "hotbar_6", "hotbar_7"
+}
+
+function ControlsPanel.setKeymap(map, onChanged)
+    keymap = map or {}
+    keymapChangedCallback = onChanged
+end
+
+function ControlsPanel.draw(layout)
+    local yOffset = layout.yOffset
+    local labelX = layout.labelX
+
+    Theme.setColor(Theme.colors.accent)
+    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
+    love.graphics.print("Controls", labelX, yOffset)
+    love.graphics.setFont(layout.settingsFont)
+    yOffset = yOffset + 30
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Keybindings", labelX, yOffset)
+    yOffset = yOffset + 30
+
+    buttonRects = {}
+
+    local mx, my = layout.mx, layout.scrolledMouseY
+    local btnXBase = layout.x + 200
+
+    for _, action in ipairs(keybindOrder) do
+        local key = keymap[action]
+        Theme.setColor(Theme.colors.text)
+        love.graphics.print(action, layout.x + 20, yOffset)
+
+        local btnW, btnH = 100, 24
+        local btnX, btnY = btnXBase, yOffset - 2
+        local hover = mx >= btnX and mx <= btnX + btnW and my >= btnY and my <= btnY + btnH
+        local keyText = key or "Not Set"
+        if bindingAction == action then
+            keyText = Strings.getControl("press_key")
+        end
+        Theme.drawStyledButton(btnX, btnY, btnW, btnH, keyText, hover, love.timer.getTime(), nil, bindingAction == action, { compact = true })
+        buttonRects[action] = { x = btnX, y = btnY - layout.scrollY, w = btnW, h = btnH }
+        yOffset = yOffset + 30
+    end
+
+    layout.yOffset = yOffset
+    return yOffset
+end
+
+function ControlsPanel.mousepressed(x, y, button)
+    if button ~= 1 then return false end
+    for action, rect in pairs(buttonRects) do
+        if x >= rect.x and x <= rect.x + rect.w and y >= rect.y and y <= rect.y + rect.h then
+            local Sound = require("src.core.sound")
+            Sound.playSFX("button_click")
+            bindingAction = action
+            return true
+        end
+    end
+    return false
+end
+
+function ControlsPanel.keypressed(key)
+    if not bindingAction then return false end
+    Settings.setKeyBinding(bindingAction, key)
+    keymap = Settings.getKeymap() or keymap
+    if keymapChangedCallback then
+        keymapChangedCallback(keymap)
+    end
+    bindingAction = nil
+    return true
+end
+
+function ControlsPanel.isBinding()
+    return bindingAction ~= nil
+end
+
+function ControlsPanel.resetBinding()
+    bindingAction = nil
+end
+
+function ControlsPanel.getContentHeight(baseY)
+    local yOffset = baseY
+    yOffset = yOffset + 30
+    yOffset = yOffset + 30
+    yOffset = yOffset + 30 * #keybindOrder
+    return yOffset
+end
+
+return ControlsPanel

--- a/src/ui/settings/graphics_panel.lua
+++ b/src/ui/settings/graphics_panel.lua
@@ -1,0 +1,814 @@
+local Theme = require("src.core.theme")
+local Viewport = require("src.core.viewport")
+local Dropdown = require("src.ui.common.dropdown")
+local Strings = require("src.core.strings")
+
+local GraphicsPanel = {}
+
+local currentSettings
+
+local vsyncTypes = {Strings.getUI("off"), Strings.getUI("on")}
+local fpsLimitTypes = {Strings.getUI("unlimited"), "30", "60", "120", "144", "240"}
+
+local vsyncDropdown
+local fpsLimitDropdown
+
+local reticleGalleryOpen = false
+local accentGalleryOpen = false
+
+local accentColorSliders = {
+    r = { value = 0.7, dragging = false },
+    g = { value = 0.7, dragging = false },
+    b = { value = 0.7, dragging = false }
+}
+
+local accentThemeLastChanged = 0
+local accentThemeChangeDuration = 0.5
+
+local reticlePopup
+local reticleSpectrum
+local reticleDone
+
+local accentPopup
+local accentSpectrum
+local accentDone
+
+local function cloneSettings(src)
+    if not src then return {} end
+    local copy = {}
+    for k, v in pairs(src) do
+        if type(v) == "table" then
+            copy[k] = cloneSettings(v)
+        else
+            copy[k] = v
+        end
+    end
+    return copy
+end
+
+local accentThemes = {
+    { name = "Cyan/Lavender", color = {0.2, 0.8, 0.9, 1.0} },
+    { name = "Blue/Purple", color = {0.4, 0.6, 1.0, 1.0} },
+    { name = "Green/Emerald", color = {0.3, 0.9, 0.4, 1.0} },
+    { name = "Red/Orange", color = {0.9, 0.3, 0.2, 1.0} },
+    { name = "Monochrome", color = {0.7, 0.7, 0.7, 1.0} },
+    { name = "Custom", color = {0.7, 0.7, 0.7, 1.0} }
+}
+
+local function hsvToRgb(h, s, v)
+    local r, g, b
+    local i = math.floor(h / 60)
+    local f = (h / 60) - i
+    local p = v * (1 - s)
+    local q = v * (1 - s * f)
+    local t = v * (1 - s * (1 - f))
+
+    if i == 0 then
+        r, g, b = v, t, p
+    elseif i == 1 then
+        r, g, b = q, v, p
+    elseif i == 2 then
+        r, g, b = p, v, t
+    elseif i == 3 then
+        r, g, b = p, q, v
+    elseif i == 4 then
+        r, g, b = t, p, v
+    else
+        r, g, b = v, p, q
+    end
+
+    return r, g, b
+end
+
+local function rgbToHsv(r, g, b)
+    local max = math.max(r, g, b)
+    local min = math.min(r, g, b)
+    local diff = max - min
+
+    local h = 0
+    local s = max == 0 and 0 or (diff / max)
+    local v = max
+
+    if diff ~= 0 then
+        if max == r then
+            h = ((g - b) / diff) % 6
+        elseif max == g then
+            h = (b - r) / diff + 2
+        else
+            h = (r - g) / diff + 4
+        end
+        h = h * 60
+        if h < 0 then h = h + 360 end
+    end
+
+    return { h = h, s = s, v = v }
+end
+
+local function applyCustomAccentColor(r, g, b)
+    local ThemeMod = require("src.core.theme")
+
+    ThemeMod.colors.accent = {r, g, b, 1.00}
+    ThemeMod.colors.accentGold = {r, g, b, 1.00}
+    ThemeMod.colors.accentTeal = {r, g, b, 1.00}
+    ThemeMod.colors.accentPink = {r, g, b, 1.00}
+    ThemeMod.colors.border = {r, g, b, 0.8}
+    ThemeMod.colors.borderBright = {r, g, b, 0.8}
+
+    ThemeMod.turretSlotColors = {
+        {r, g, b, 1.00},
+        {r, g, b, 1.00},
+        {r, g, b, 1.00},
+        {r, g, b, 1.00},
+    }
+
+    if currentSettings then
+        currentSettings.accent_color_rgb = {r, g, b, 1.0}
+        currentSettings.accent_theme = "Custom"
+    end
+
+    accentThemeLastChanged = love.timer.getTime()
+end
+
+local function applyAccentTheme(themeName)
+    local ThemeMod = require("src.core.theme")
+
+    if themeName == "Cyan/Lavender" then
+        ThemeMod.colors.accent = {0.2, 0.8, 0.9, 1.00}
+        ThemeMod.colors.accentGold = {0.2, 0.8, 0.9, 1.00}
+        ThemeMod.colors.accentTeal = {0.2, 0.8, 0.9, 1.00}
+        ThemeMod.colors.accentPink = {0.2, 0.8, 0.9, 1.00}
+        ThemeMod.colors.border = {0.5, 0.7, 0.9, 0.8}
+        ThemeMod.colors.borderBright = {0.5, 0.7, 0.9, 0.8}
+        ThemeMod.colors.bg0 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.bg1 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.windowBg = {0.00, 0.00, 0.00, 1.00}
+    elseif themeName == "Blue/Purple" then
+        ThemeMod.colors.accent = {0.4, 0.6, 1.0, 1.00}
+        ThemeMod.colors.accentGold = {0.4, 0.6, 1.0, 1.00}
+        ThemeMod.colors.accentTeal = {0.4, 0.6, 1.0, 1.00}
+        ThemeMod.colors.accentPink = {0.4, 0.6, 1.0, 1.00}
+        ThemeMod.colors.border = {0.4, 0.6, 1.0, 0.8}
+        ThemeMod.colors.borderBright = {0.4, 0.6, 1.0, 0.8}
+        ThemeMod.colors.bg0 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.bg1 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.windowBg = {0.00, 0.00, 0.00, 1.00}
+    elseif themeName == "Green/Emerald" then
+        ThemeMod.colors.accent = {0.3, 0.9, 0.4, 1.00}
+        ThemeMod.colors.accentGold = {0.3, 0.9, 0.4, 1.00}
+        ThemeMod.colors.accentTeal = {0.3, 0.9, 0.4, 1.00}
+        ThemeMod.colors.accentPink = {0.3, 0.9, 0.4, 1.00}
+        ThemeMod.colors.border = {0.3, 0.9, 0.4, 0.8}
+        ThemeMod.colors.borderBright = {0.3, 0.9, 0.4, 0.8}
+        ThemeMod.colors.bg0 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.bg1 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.windowBg = {0.00, 0.00, 0.00, 1.00}
+    elseif themeName == "Red/Orange" then
+        ThemeMod.colors.accent = {0.9, 0.3, 0.2, 1.00}
+        ThemeMod.colors.accentGold = {0.9, 0.3, 0.2, 1.00}
+        ThemeMod.colors.accentTeal = {0.9, 0.3, 0.2, 1.00}
+        ThemeMod.colors.accentPink = {0.9, 0.3, 0.2, 1.00}
+        ThemeMod.colors.border = {0.9, 0.3, 0.2, 0.8}
+        ThemeMod.colors.borderBright = {0.9, 0.3, 0.2, 0.8}
+        ThemeMod.colors.bg0 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.bg1 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.windowBg = {0.00, 0.00, 0.00, 1.00}
+    elseif themeName == "Monochrome" then
+        ThemeMod.colors.accent = {0.7, 0.7, 0.7, 1.00}
+        ThemeMod.colors.accentGold = {0.7, 0.7, 0.7, 1.00}
+        ThemeMod.colors.accentTeal = {0.7, 0.7, 0.7, 1.00}
+        ThemeMod.colors.accentPink = {0.7, 0.7, 0.7, 1.00}
+        ThemeMod.colors.border = {0.7, 0.7, 0.7, 0.8}
+        ThemeMod.colors.borderBright = {0.7, 0.7, 0.7, 0.8}
+        ThemeMod.colors.bg0 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.bg1 = {0.00, 0.00, 0.00, 1.00}
+        ThemeMod.colors.windowBg = {0.00, 0.00, 0.00, 1.00}
+    end
+
+    if themeName ~= "Custom" and currentSettings then
+        currentSettings.accent_theme = themeName
+        currentSettings.accent_color_rgb = nil
+    end
+
+    accentThemeLastChanged = love.timer.getTime()
+end
+
+local function ensureDropdowns()
+    if not vsyncDropdown then
+        vsyncDropdown = Dropdown.new({
+            x = 0,
+            y = 0,
+            options = vsyncTypes,
+            selectedIndex = 1,
+            onSelect = function(index)
+                if currentSettings then
+                    currentSettings.vsync = (index == 2)
+                end
+            end
+        })
+    end
+
+    if not fpsLimitDropdown then
+        fpsLimitDropdown = Dropdown.new({
+            x = 0,
+            y = 0,
+            options = fpsLimitTypes,
+            selectedIndex = 3,
+            onSelect = function(index)
+                if not currentSettings then return end
+                local fpsMap = {
+                    [1] = 0,
+                    [2] = 30,
+                    [3] = 60,
+                    [4] = 120,
+                    [5] = 144,
+                    [6] = 240
+                }
+                currentSettings.max_fps_index = index
+                currentSettings.max_fps = fpsMap[index] or 60
+            end
+        })
+    end
+end
+
+local function refreshDropdowns()
+    if not currentSettings then return end
+    ensureDropdowns()
+
+    vsyncDropdown:setSelectedIndex(currentSettings.vsync and 2 or 1)
+
+    local fpsToIndex = {
+        [0] = 1,
+        [30] = 2,
+        [60] = 3,
+        [120] = 4,
+        [144] = 5,
+        [240] = 6
+    }
+    local idx = fpsToIndex[currentSettings.max_fps or 60] or 3
+    currentSettings.max_fps_index = idx
+    fpsLimitDropdown:setSelectedIndex(idx)
+end
+
+local function drawReticlePreview(previewSize)
+    love.graphics.push()
+    love.graphics.translate(previewSize * 0.5, previewSize * 0.5)
+    local styleIndex = math.max(1, math.min(50, currentSettings and currentSettings.reticle_style or 1))
+    local pointerScale = 0.9 + (styleIndex - 1) / 49 * 0.6
+    local baseScale = (previewSize / 32) * 0.95
+    love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
+    Theme.setColor(Theme.colors.textHighlight)
+    love.graphics.setLineWidth(1)
+    love.graphics.line(-8, 0, 8, 0)
+    love.graphics.line(0, -8, 0, 8)
+    love.graphics.circle('fill', 0, 0, 1)
+    love.graphics.pop()
+end
+
+local function drawReticleGallery()
+    if not reticleGalleryOpen then
+        reticlePopup = nil
+        reticleSpectrum = nil
+        reticleDone = nil
+        return
+    end
+
+    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
+    local gw, gh = 700, 600
+    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
+    Theme.drawGradientGlowRect(gx, gy, gw, gh, 6, Theme.colors.bg1, Theme.colors.bg0, Theme.colors.accent, Theme.effects.glowWeak)
+    Theme.drawEVEBorder(gx, gy, gw, gh, 6, Theme.colors.border, 8)
+    Theme.setColor(Theme.colors.textHighlight)
+    love.graphics.print(Strings.getUI("choose_reticle"), gx + 16, gy + 12)
+
+    local pickerY = gy + 50
+    local pickerX = gx + 20
+    local pickerSize = 200
+    local previewSize = 80
+
+    local function getCurrentRGB()
+        if not currentSettings then return 1, 1, 1 end
+        local c = currentSettings.reticle_color_rgb
+        if c and type(c) == 'table' then
+            return c[1] or 1, c[2] or 1, c[3] or 1
+        end
+        local ThemeMod = require('src.core.theme')
+        local name = currentSettings.reticle_color or 'accent'
+        local map = {
+            accent = ThemeMod.colors.accent,
+            white = {1,1,1,1},
+            cyan = ThemeMod.colors.info,
+            green = ThemeMod.colors.success,
+            red = ThemeMod.colors.danger,
+            yellow = ThemeMod.colors.warning,
+            magenta = ThemeMod.colors.accentPink,
+            teal = ThemeMod.colors.accentTeal,
+            gold = ThemeMod.colors.accentGold,
+        }
+        local cc = map[(name or 'accent'):lower()] or ThemeMod.colors.accent
+        return cc[1], cc[2], cc[3]
+    end
+
+    local cr, cg, cb = getCurrentRGB()
+
+    local spectrumX = pickerX
+    local spectrumY = pickerY
+    local spectrumW = pickerSize
+    local spectrumH = pickerSize
+
+    for x = 0, spectrumW - 1 do
+        for y = 0, spectrumH - 1 do
+            local h = (x / spectrumW) * 360
+            local s = 1.0
+            local v = 1.0 - (y / spectrumH)
+            local r, g, b = hsvToRgb(h, s, v)
+            Theme.setColor({r, g, b, 1})
+            love.graphics.rectangle("fill", spectrumX + x, spectrumY + y, 1, 1)
+        end
+    end
+
+    Theme.setColor(Theme.colors.border)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle("line", spectrumX, spectrumY, spectrumW, spectrumH)
+
+    local currentH = rgbToHsv(cr, cg, cb)
+    local indicatorX = spectrumX + (currentH.h / 360) * spectrumW
+    local indicatorY = spectrumY + (1 - currentH.v) * spectrumH
+
+    Theme.setColor({1, 1, 1, 1})
+    love.graphics.setLineWidth(2)
+    love.graphics.line(indicatorX - 8, indicatorY, indicatorX + 8, indicatorY)
+    love.graphics.line(indicatorX, indicatorY - 8, indicatorX, indicatorY + 8)
+    Theme.setColor({0, 0, 0, 1})
+    love.graphics.setLineWidth(1)
+    love.graphics.line(indicatorX - 9, indicatorY, indicatorX + 9, indicatorY)
+    love.graphics.line(indicatorX, indicatorY - 9, indicatorX, indicatorY + 9)
+
+    reticleSpectrum = { x = spectrumX, y = spectrumY, w = spectrumW, h = spectrumH }
+
+    local previewX = pickerX + pickerSize + 20
+    local previewY = pickerY
+    Theme.setColor({cr, cg, cb, 1})
+    love.graphics.rectangle("fill", previewX, previewY, previewSize, previewSize)
+    Theme.setColor(Theme.colors.border)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle("line", previewX, previewY, previewSize, previewSize)
+
+    Theme.setColor(Theme.colors.text)
+    local labelText = "Cursor Color"
+    local labelW = Theme.fonts.small:getWidth(labelText)
+    love.graphics.print(labelText, previewX + (previewSize - labelW) / 2, previewY - 20)
+
+    local rgbY = previewY + previewSize + 10
+    local rgbText = string.format("R: %d  G: %d  B: %d",
+        math.floor(cr * 255),
+        math.floor(cg * 255),
+        math.floor(cb * 255))
+    love.graphics.print(rgbText, previewX, rgbY)
+
+    local hsvY = rgbY + 15
+    local hsvText = string.format("H: %d°  S: %d%%  V: %d%%",
+        math.floor(currentH.h),
+        math.floor(currentH.s * 100),
+        math.floor(currentH.v * 100))
+    love.graphics.print(hsvText, previewX, hsvY)
+
+    local px, py = gx + 16, pickerY + pickerSize + 20
+    local cols, cell, gap = 10, 44, 8
+    local total, rows = 50, math.ceil(50/cols)
+    reticlePopup = { x = px, y = py, cols = cols, rows = rows, cell = cell, gap = gap }
+    local curStyle = currentSettings and currentSettings.reticle_style or 1
+    for i = 1, total do
+        local r = math.floor((i-1)/cols)
+        local c = (i-1) % cols
+        local cx = px + c * (cell + gap)
+        local cy = py + r * (cell + gap)
+        local isSel = (i == curStyle)
+        Theme.drawGradientGlowRect(cx, cy, cell, cell, 3, isSel and Theme.colors.bg3 or Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
+        love.graphics.push()
+        love.graphics.translate(cx + cell / 2, cy + cell / 2)
+        local pointerScale = 0.9 + (i - 1) / 49 * 0.6
+        local baseScale = (cell / 32) * 0.95
+        love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
+        Theme.setColor(Theme.colors.textHighlight)
+        love.graphics.setLineWidth(1)
+        love.graphics.line(-8, 0, 8, 0)
+        love.graphics.line(0, -8, 0, 8)
+        love.graphics.circle('fill', 0, 0, 1)
+        love.graphics.pop()
+    end
+
+    local doneW, doneH = 120, 32
+    local doneX = gx + gw - doneW - 20
+    local doneY = gy + gh - doneH - 20
+    Theme.drawStyledButton(doneX, doneY, doneW, doneH, Strings.getUI("done"), false, love.timer.getTime())
+    reticleDone = { _rect = { x = doneX, y = doneY, w = doneW, h = doneH } }
+end
+
+local function drawAccentGallery()
+    if not accentGalleryOpen then
+        accentPopup = nil
+        accentSpectrum = nil
+        accentDone = nil
+        GraphicsPanel._colorPickerSliders = nil
+        return
+    end
+
+    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
+    local gw, gh = 600, 450
+    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
+    Theme.drawGradientGlowRect(gx, gy, gw, gh, 6, Theme.colors.bg1, Theme.colors.bg0, Theme.colors.accent, Theme.effects.glowWeak)
+    Theme.drawEVEBorder(gx, gy, gw, gh, 6, Theme.colors.border, 8)
+    Theme.setColor(Theme.colors.textHighlight)
+    love.graphics.print("Choose Accent Theme", gx + 16, gy + 12)
+
+    local pickerX = gx + 20
+    local pickerY = gy + 60
+    local pickerSize = 200
+    local previewSize = 80
+
+    local cr, cg, cb = accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value
+    if currentSettings and currentSettings.accent_color_rgb then
+        cr = currentSettings.accent_color_rgb[1]
+        cg = currentSettings.accent_color_rgb[2]
+        cb = currentSettings.accent_color_rgb[3]
+    end
+
+    local spectrumX = pickerX
+    local spectrumY = pickerY
+    local spectrumW = pickerSize
+    local spectrumH = pickerSize
+
+    for x = 0, spectrumW - 1 do
+        for y = 0, spectrumH - 1 do
+            local h = (x / spectrumW) * 360
+            local s = 1.0
+            local v = 1.0 - (y / spectrumH)
+            local r, g, b = hsvToRgb(h, s, v)
+            Theme.setColor({r, g, b, 1})
+            love.graphics.rectangle("fill", spectrumX + x, spectrumY + y, 1, 1)
+        end
+    end
+
+    Theme.setColor(Theme.colors.border)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle("line", spectrumX, spectrumY, spectrumW, spectrumH)
+
+    local currentH = rgbToHsv(cr, cg, cb)
+    local indicatorX = spectrumX + (currentH.h / 360) * spectrumW
+    local indicatorY = spectrumY + (1 - currentH.v) * spectrumH
+
+    Theme.setColor({1, 1, 1, 1})
+    love.graphics.setLineWidth(2)
+    love.graphics.line(indicatorX - 8, indicatorY, indicatorX + 8, indicatorY)
+    love.graphics.line(indicatorX, indicatorY - 8, indicatorX, indicatorY + 8)
+    Theme.setColor({0, 0, 0, 1})
+    love.graphics.setLineWidth(1)
+    love.graphics.line(indicatorX - 9, indicatorY, indicatorX + 9, indicatorY)
+    love.graphics.line(indicatorX, indicatorY - 9, indicatorX, indicatorY + 9)
+
+    accentSpectrum = { x = spectrumX, y = spectrumY, w = spectrumW, h = spectrumH }
+
+    local previewX = pickerX + pickerSize + 20
+    local previewY = pickerY
+    Theme.setColor({cr, cg, cb, 1})
+    love.graphics.rectangle("fill", previewX, previewY, previewSize, previewSize)
+    Theme.setColor(Theme.colors.border)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle("line", previewX, previewY, previewSize, previewSize)
+
+    Theme.setColor(Theme.colors.text)
+    local labelText = "Custom Color"
+    local labelW = Theme.fonts.small:getWidth(labelText)
+    love.graphics.print(labelText, previewX + (previewSize - labelW) / 2, previewY - 20)
+
+    local rgbY = previewY + previewSize + 10
+    local rgbText = string.format("R: %d  G: %d  B: %d",
+        math.floor(cr * 255),
+        math.floor(cg * 255),
+        math.floor(cb * 255))
+    love.graphics.print(rgbText, previewX, rgbY)
+
+    local hsvY = rgbY + 15
+    local hsvText = string.format("H: %d°  S: %d%%  V: %d%%",
+        math.floor(currentH.h),
+        math.floor(currentH.s * 100),
+        math.floor(currentH.v * 100))
+    love.graphics.print(hsvText, previewX, hsvY)
+
+    local doneW, doneH = 90, 28
+    local doneX, doneY = gx + gw - doneW - 16, gy + gh - doneH - 12
+    local mx, my = Viewport.getMousePosition()
+    local doneHover = mx >= doneX and mx <= doneX + doneW and my >= doneY and my <= doneY + doneH
+    Theme.drawStyledButton(doneX, doneY, doneW, doneH, "Done", doneHover, love.timer.getTime())
+    accentDone = { _rect = { x = doneX, y = doneY, w = doneW, h = doneH } }
+
+    GraphicsPanel._colorPickerSliders = {}
+    local sliderStartY = previewY + previewSize + 60
+    local sliderWidth = previewSize + pickerSize - 20
+    for idx, channel in ipairs({"r", "g", "b"}) do
+        local sliderY = sliderStartY + (idx - 1) * 30
+        local sliderX = pickerX
+        Theme.drawGradientGlowRect(sliderX, sliderY, sliderWidth, 10, 2, Theme.colors.bg3, Theme.colors.bg2, Theme.colors.border, Theme.effects.glowWeak * 0.1)
+        local handleX = sliderX + (sliderWidth - 10) * accentColorSliders[channel].value
+        Theme.drawGradientGlowRect(handleX, sliderY - 4, 10, 18, 2, Theme.colors.accent, Theme.colors.bg3, Theme.colors.border, Theme.effects.glowWeak * 0.2)
+        GraphicsPanel._colorPickerSliders[channel] = { x = sliderX, y = sliderY - 4, w = sliderWidth, h = 18 }
+    end
+end
+
+local function handleReticleGalleryClick(screenX, screenY)
+    if not reticleGalleryOpen then
+        return false
+    end
+
+    if reticleDone and screenX >= reticleDone._rect.x and screenX <= reticleDone._rect.x + reticleDone._rect.w and screenY >= reticleDone._rect.y and screenY <= reticleDone._rect.y + reticleDone._rect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        reticleGalleryOpen = false
+        return true
+    end
+
+    if reticlePopup and screenX >= reticlePopup.x and screenY >= reticlePopup.y then
+        local col = math.floor((screenX - reticlePopup.x) / (reticlePopup.cell + reticlePopup.gap))
+        local row = math.floor((screenY - reticlePopup.y) / (reticlePopup.cell + reticlePopup.gap))
+        if col >= 0 and col < reticlePopup.cols and row >= 0 and row < reticlePopup.rows then
+            local index = row * reticlePopup.cols + col + 1
+            if index >= 1 and index <= 50 and currentSettings then
+                currentSettings.reticle_style = index
+                return true
+            end
+        end
+    end
+
+    if reticleSpectrum and screenX >= reticleSpectrum.x and screenX <= reticleSpectrum.x + reticleSpectrum.w and screenY >= reticleSpectrum.y and screenY <= reticleSpectrum.y + reticleSpectrum.h then
+        local h = ((screenX - reticleSpectrum.x) / reticleSpectrum.w) * 360
+        local v = 1.0 - ((screenY - reticleSpectrum.y) / reticleSpectrum.h)
+        local s = 1.0
+
+        local r, g, b = hsvToRgb(h, s, v)
+
+        if currentSettings then
+            currentSettings.reticle_color_rgb = {r, g, b, 1.0}
+            currentSettings.reticle_color = nil
+        end
+        return true
+    end
+
+    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
+    local gw, gh = 700, 600
+    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
+    if screenX >= gx and screenX <= gx + gw and screenY >= gy and screenY <= gy + gh then
+        return true
+    end
+
+    return false
+end
+
+local function handleAccentGalleryClick(screenX, screenY)
+    if not accentGalleryOpen then
+        return false
+    end
+
+    if accentDone and screenX >= accentDone._rect.x and screenX <= accentDone._rect.x + accentDone._rect.w and screenY >= accentDone._rect.y and screenY <= accentDone._rect.y + accentDone._rect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        accentGalleryOpen = false
+        return true
+    end
+
+    if accentSpectrum and screenX >= accentSpectrum.x and screenX <= accentSpectrum.x + accentSpectrum.w and screenY >= accentSpectrum.y and screenY <= accentSpectrum.y + accentSpectrum.h then
+        local h = ((screenX - accentSpectrum.x) / accentSpectrum.w) * 360
+        local v = 1.0 - ((screenY - accentSpectrum.y) / accentSpectrum.h)
+        local s = 1.0
+
+        local r, g, b = hsvToRgb(h, s, v)
+
+        accentColorSliders.r.value = r
+        accentColorSliders.g.value = g
+        accentColorSliders.b.value = b
+
+        applyCustomAccentColor(r, g, b)
+        return true
+    end
+
+    if GraphicsPanel._colorPickerSliders then
+        for channel, rect in pairs(GraphicsPanel._colorPickerSliders) do
+            if screenX >= rect.x and screenX <= rect.x + rect.w and screenY >= rect.y and screenY <= rect.y + rect.h then
+                local value = math.max(0, math.min(1, (screenX - rect.x) / rect.w))
+                accentColorSliders[channel].value = value
+                accentColorSliders[channel].dragging = true
+                applyCustomAccentColor(accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value)
+                return true
+            end
+        end
+    end
+
+    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
+    local gw, gh = 600, 450
+    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
+    if screenX >= gx and screenX <= gx + gw and screenY >= gy and screenY <= gy + gh then
+        return true
+    end
+
+    return false
+end
+
+function GraphicsPanel.init()
+    ensureDropdowns()
+end
+
+function GraphicsPanel.setSettings(settings)
+    currentSettings = settings
+    refreshDropdowns()
+
+    if currentSettings then
+        if currentSettings.accent_color_rgb and currentSettings.accent_theme == "Custom" then
+            local rgb = currentSettings.accent_color_rgb
+            accentColorSliders.r.value = rgb[1] or 0.7
+            accentColorSliders.g.value = rgb[2] or 0.7
+            accentColorSliders.b.value = rgb[3] or 0.7
+            applyCustomAccentColor(accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value)
+        else
+            applyAccentTheme(currentSettings.accent_theme or "Monochrome")
+        end
+    end
+end
+
+function GraphicsPanel.draw(layout)
+    ensureDropdowns()
+
+    local yOffset = layout.yOffset
+    local labelX = layout.labelX
+    local valueX = layout.valueX
+    local itemHeight = layout.itemHeight
+    local mx, scrolledMouseY = layout.mx, layout.scrolledMouseY
+
+    Theme.setColor(Theme.colors.accent)
+    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
+    love.graphics.print("Graphics Settings", labelX, yOffset)
+    love.graphics.setFont(layout.settingsFont)
+    yOffset = yOffset + 30
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("VSync:", labelX, yOffset)
+    vsyncDropdown:setPosition(valueX, yOffset - 2 - layout.scrollY)
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Max FPS:", labelX, yOffset)
+    fpsLimitDropdown:setPosition(valueX, yOffset - 2 - layout.scrollY)
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Show FPS:", labelX, yOffset)
+    local showFpsToggleX = valueX
+    local showFpsToggleY = yOffset - 4
+    local showFpsToggleW = 60
+    local showFpsToggleH = 26
+    local showFpsToggleHover = mx >= showFpsToggleX and mx <= showFpsToggleX + showFpsToggleW and scrolledMouseY >= showFpsToggleY and scrolledMouseY <= showFpsToggleY + showFpsToggleH
+    local showFpsToggleActive = currentSettings and currentSettings.show_fps or false
+    Theme.drawStyledButton(showFpsToggleX, showFpsToggleY, showFpsToggleW, showFpsToggleH, showFpsToggleActive and "ON" or "OFF", showFpsToggleHover, love.timer.getTime())
+    GraphicsPanel._showFpsToggleRect = { x = showFpsToggleX, y = showFpsToggleY - layout.scrollY, w = showFpsToggleW, h = showFpsToggleH }
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Cursor:", labelX, yOffset)
+    local cursorBtnX, cursorBtnY, cursorBtnW, cursorBtnH = valueX, yOffset - 4, 140, 26
+    local cursorBtnHover = mx >= cursorBtnX and mx <= cursorBtnX + cursorBtnW and scrolledMouseY >= cursorBtnY and scrolledMouseY <= cursorBtnY + cursorBtnH
+    Theme.drawStyledButton(cursorBtnX, cursorBtnY, cursorBtnW, cursorBtnH, "Select Cursor", cursorBtnHover, love.timer.getTime())
+    GraphicsPanel._reticleButtonRect = { x = cursorBtnX, y = cursorBtnY - layout.scrollY, w = cursorBtnW, h = cursorBtnH }
+    local previewSize = cursorBtnH
+    local pvX, pvY = cursorBtnX + cursorBtnW + 10, cursorBtnY
+    Theme.drawGradientGlowRect(pvX, pvY, previewSize, previewSize, 3, Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
+    love.graphics.push()
+    love.graphics.translate(pvX, pvY)
+    drawReticlePreview(previewSize)
+    love.graphics.pop()
+    yOffset = yOffset + itemHeight
+
+    Theme.setColor(Theme.colors.text)
+    love.graphics.print("Accent Color:", labelX, yOffset)
+    local accentBtnX, accentBtnY, accentBtnW, accentBtnH = valueX, yOffset - 4, 140, 26
+    local accentBtnHover = mx >= accentBtnX and mx <= accentBtnX + accentBtnW and scrolledMouseY >= accentBtnY and scrolledMouseY <= accentBtnY + accentBtnH
+    Theme.drawStyledButton(accentBtnX, accentBtnY, accentBtnW, accentBtnH, "Select Accent", accentBtnHover, love.timer.getTime())
+    GraphicsPanel._accentButtonRect = { x = accentBtnX, y = accentBtnY - layout.scrollY, w = accentBtnW, h = accentBtnH }
+
+    local accentPreviewSize = accentBtnH
+    local accentPreviewX, accentPreviewY = accentBtnX + accentBtnW + 10, accentBtnY
+    Theme.drawGradientGlowRect(accentPreviewX, accentPreviewY, accentPreviewSize, accentPreviewSize, 3, Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
+    local currentTheme = currentSettings and currentSettings.accent_theme or "Monochrome"
+    local previewColor = Theme.colors.accent
+    if currentTheme == "Custom" and currentSettings and currentSettings.accent_color_rgb then
+        previewColor = currentSettings.accent_color_rgb
+    end
+    Theme.setColor(previewColor)
+    love.graphics.rectangle("fill", accentPreviewX + 2, accentPreviewY + 2, accentPreviewSize - 4, accentPreviewSize - 4)
+    Theme.setColor(Theme.colors.text)
+    local themeText = currentTheme
+    local themeTextX = accentPreviewX + accentPreviewSize + 10
+    local themeTextY = accentPreviewY + (accentPreviewSize - Theme.fonts.medium:getHeight()) / 2
+    love.graphics.print(themeText, themeTextX, themeTextY)
+    yOffset = yOffset + itemHeight
+
+    layout.yOffset = yOffset
+    return yOffset
+end
+
+function GraphicsPanel.drawOverlays()
+    drawReticleGallery()
+    drawAccentGallery()
+end
+
+function GraphicsPanel.drawForeground(mx, my)
+    if vsyncDropdown then
+        vsyncDropdown:drawButtonOnly(mx, my)
+        fpsLimitDropdown:drawButtonOnly(mx, my)
+        vsyncDropdown:drawOptionsOnly(mx, my)
+        fpsLimitDropdown:drawOptionsOnly(mx, my)
+    end
+end
+
+function GraphicsPanel.mousepressed(raw_x, raw_y, button)
+    if button ~= 1 then return false end
+
+    local screenX, screenY = Viewport.toScreen(raw_x, raw_y)
+    if handleReticleGalleryClick(screenX, screenY) then return true end
+    if handleAccentGalleryClick(screenX, screenY) then return true end
+
+    if GraphicsPanel._reticleButtonRect and raw_x >= GraphicsPanel._reticleButtonRect.x and raw_x <= GraphicsPanel._reticleButtonRect.x + GraphicsPanel._reticleButtonRect.w and raw_y >= GraphicsPanel._reticleButtonRect.y and raw_y <= GraphicsPanel._reticleButtonRect.y + GraphicsPanel._reticleButtonRect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        reticleGalleryOpen = true
+        return true
+    end
+
+    if GraphicsPanel._accentButtonRect and raw_x >= GraphicsPanel._accentButtonRect.x and raw_x <= GraphicsPanel._accentButtonRect.x + GraphicsPanel._accentButtonRect.w and raw_y >= GraphicsPanel._accentButtonRect.y and raw_y <= GraphicsPanel._accentButtonRect.y + GraphicsPanel._accentButtonRect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        accentGalleryOpen = not accentGalleryOpen
+        return true
+    end
+
+    if GraphicsPanel._showFpsToggleRect and raw_x >= GraphicsPanel._showFpsToggleRect.x and raw_x <= GraphicsPanel._showFpsToggleRect.x + GraphicsPanel._showFpsToggleRect.w and raw_y >= GraphicsPanel._showFpsToggleRect.y and raw_y <= GraphicsPanel._showFpsToggleRect.y + GraphicsPanel._showFpsToggleRect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        if currentSettings then
+            currentSettings.show_fps = not currentSettings.show_fps
+        end
+        return true
+    end
+
+    if vsyncDropdown and vsyncDropdown:mousepressed(raw_x, raw_y, button) then return true end
+    if fpsLimitDropdown and fpsLimitDropdown:mousepressed(raw_x, raw_y, button) then return true end
+
+    return false
+end
+
+function GraphicsPanel.mousemoved(x, y)
+    if GraphicsPanel._colorPickerSliders then
+        for channel, slider in pairs(GraphicsPanel._colorPickerSliders) do
+            if accentColorSliders[channel].dragging then
+                local value = math.max(0, math.min(1, (x - slider.x) / slider.w))
+                accentColorSliders[channel].value = value
+                applyCustomAccentColor(accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value)
+            end
+        end
+    end
+
+    if vsyncDropdown then vsyncDropdown:mousemoved(x, y) end
+    if fpsLimitDropdown then fpsLimitDropdown:mousemoved(x, y) end
+end
+
+function GraphicsPanel.mousereleased()
+    GraphicsPanel.stopDragging()
+end
+
+function GraphicsPanel.stopDragging()
+    for _, slider in pairs(accentColorSliders) do
+        slider.dragging = false
+    end
+end
+
+function GraphicsPanel.beginSliderDrag(channel)
+    if accentColorSliders[channel] then
+        accentColorSliders[channel].dragging = true
+    end
+end
+
+function GraphicsPanel.getContentHeight(baseY, itemHeight)
+    local yOffset = baseY
+    yOffset = yOffset + 30 -- section label
+    yOffset = yOffset + itemHeight -- vsync
+    yOffset = yOffset + itemHeight -- fps
+    yOffset = yOffset + itemHeight -- show fps
+    yOffset = yOffset + itemHeight -- cursor
+    yOffset = yOffset + itemHeight -- accent
+    return yOffset
+end
+
+GraphicsPanel.refreshDropdowns = refreshDropdowns
+GraphicsPanel.applyAccentTheme = applyAccentTheme
+GraphicsPanel.applyCustomAccentColor = applyCustomAccentColor
+GraphicsPanel.handleReticleGalleryClick = handleReticleGalleryClick
+GraphicsPanel.handleAccentGalleryClick = handleAccentGalleryClick
+
+return GraphicsPanel

--- a/src/ui/settings_panel.lua
+++ b/src/ui/settings_panel.lua
@@ -3,288 +3,28 @@ local Viewport = require("src.core.viewport")
 local Settings = require("src.core.settings")
 local Notifications = require("src.ui.notifications")
 local Window = require("src.ui.common.window")
-local Dropdown = require("src.ui.common.dropdown")
 local Strings = require("src.core.strings")
 local Util = require("src.core.util")
-    -- SciFiCursor removed - using simple reticle
+local Log = require("src.core.log")
+
+local GraphicsPanel = require("src.ui.settings.graphics_panel")
+local AudioPanel = require("src.ui.settings.audio_panel")
+local ControlsPanel = require("src.ui.settings.controls_panel")
 
 local SettingsPanel = {}
 
 SettingsPanel.visible = false
-
--- Aurora shader for title effect (initialized on first use)
 SettingsPanel.auroraShader = nil
 
-local currentGraphicsSettings
-local currentAudioSettings
+local currentGraphicsSettings = {}
+local currentAudioSettings = {}
 local originalGraphicsSettings
 local originalAudioSettings
-local keymap
-local bindingAction
-local draggingSlider = nil
+local keymap = {}
 
-local vsyncTypes = {Strings.getUI("off"), Strings.getUI("on")}
-local fpsLimitTypes = {Strings.getUI("unlimited"), "30", "60", "120", "144", "240"}
--- Reticle color picker state (always visible sliders in popup)
-local reticleGalleryOpen = false
 local scrollY = 0
 local scrollDragOffset = 0
-local contentHeight = 0 -- Will be calculated dynamically
-
--- Track when accent theme was last changed for visual feedback
-local accentThemeLastChanged = 0
-local accentThemeChangeDuration = 0.5 -- Duration of highlight effect in seconds
-
--- Function to apply custom accent color from RGB values
-local function applyCustomAccentColor(r, g, b)
-    local Theme = require("src.core.theme")
-    
-    -- Apply the custom color to all accent variants
-    Theme.colors.accent = {r, g, b, 1.00}
-    Theme.colors.accentGold = {r, g, b, 1.00}
-    Theme.colors.accentTeal = {r, g, b, 1.00}
-    Theme.colors.accentPink = {r, g, b, 1.00}
-    Theme.colors.border = {r, g, b, 0.8}
-    Theme.colors.borderBright = {r, g, b, 0.8}
-    
-    -- Update turret slot colors to match
-    Theme.turretSlotColors = {
-        {r, g, b, 1.00},
-        {r, g, b, 1.00},
-        {r, g, b, 1.00},
-        {r, g, b, 1.00},
-    }
-    
-    -- Store the custom color in settings
-    currentGraphicsSettings.accent_color_rgb = {r, g, b, 1.0}
-    currentGraphicsSettings.accent_theme = "Custom"
-    
-    accentThemeLastChanged = love.timer.getTime()
-end
-
--- Standardized dropdown components
-local vsyncDropdown
-local fpsLimitDropdown
-local accentThemeDropdown
-
--- Accent color gallery state (similar to reticle gallery)
-local accentGalleryOpen = false
-local accentColorSliders = {
-    r = { value = 0.7, dragging = false },
-    g = { value = 0.7, dragging = false },
-    b = { value = 0.7, dragging = false }
-}
-
--- Available accent themes
-local accentThemes = {
-    { name = "Cyan/Lavender", color = {0.2, 0.8, 0.9, 1.0} },
-    { name = "Blue/Purple", color = {0.4, 0.6, 1.0, 1.0} },
-    { name = "Green/Emerald", color = {0.3, 0.9, 0.4, 1.0} },
-    { name = "Red/Orange", color = {0.9, 0.3, 0.2, 1.0} },
-    { name = "Monochrome", color = {0.7, 0.7, 0.7, 1.0} },
-    { name = "Custom", color = {0.7, 0.7, 0.7, 1.0} }
-}
-
--- HSV to RGB conversion
-local function hsvToRgb(h, s, v)
-    local r, g, b
-    local i = math.floor(h / 60)
-    local f = (h / 60) - i
-    local p = v * (1 - s)
-    local q = v * (1 - s * f)
-    local t = v * (1 - s * (1 - f))
-    
-    if i == 0 then
-        r, g, b = v, t, p
-    elseif i == 1 then
-        r, g, b = q, v, p
-    elseif i == 2 then
-        r, g, b = p, v, t
-    elseif i == 3 then
-        r, g, b = p, q, v
-    elseif i == 4 then
-        r, g, b = t, p, v
-    else
-        r, g, b = v, p, q
-    end
-    
-    return r, g, b
-end
-
--- RGB to HSV conversion
-local function rgbToHsv(r, g, b)
-    local max = math.max(r, g, b)
-    local min = math.min(r, g, b)
-    local diff = max - min
-
-    local h = 0
-    local s = max == 0 and 0 or (diff / max)
-    local v = max
-
-    if diff ~= 0 then
-        if max == r then
-            h = ((g - b) / diff) % 6
-        elseif max == g then
-            h = (b - r) / diff + 2
-        else
-            h = (r - g) / diff + 4
-        end
-        h = h * 60
-        if h < 0 then h = h + 360 end
-    end
-
-    return { h = h, s = s, v = v }
-end
-
-local function handleReticleGalleryClick(screenX, screenY)
-    if not reticleGalleryOpen then
-        return false
-    end
-
-    if SettingsPanel._reticleDone and screenX >= SettingsPanel._reticleDone._rect.x and screenX <= SettingsPanel._reticleDone._rect.x + SettingsPanel._reticleDone._rect.w and
-       screenY >= SettingsPanel._reticleDone._rect.y and screenY <= SettingsPanel._reticleDone._rect.y + SettingsPanel._reticleDone._rect.h then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        reticleGalleryOpen = false
-        return true
-    end
-
-    if SettingsPanel._reticlePopup and screenX >= SettingsPanel._reticlePopup.x and screenY >= SettingsPanel._reticlePopup.y then
-        local col = math.floor((screenX - SettingsPanel._reticlePopup.x) / (SettingsPanel._reticlePopup.cell + SettingsPanel._reticlePopup.gap))
-        local row = math.floor((screenY - SettingsPanel._reticlePopup.y) / (SettingsPanel._reticlePopup.cell + SettingsPanel._reticlePopup.gap))
-        if col >= 0 and col < SettingsPanel._reticlePopup.cols and row >= 0 and row < SettingsPanel._reticlePopup.rows then
-            local index = row * SettingsPanel._reticlePopup.cols + col + 1
-            if index >= 1 and index <= 50 then
-                currentGraphicsSettings.reticle_style = index
-                return true
-            end
-        end
-    end
-
-    if SettingsPanel._reticleSpectrum and screenX >= SettingsPanel._reticleSpectrum.x and screenX <= SettingsPanel._reticleSpectrum.x + SettingsPanel._reticleSpectrum.w and
-       screenY >= SettingsPanel._reticleSpectrum.y and screenY <= SettingsPanel._reticleSpectrum.y + SettingsPanel._reticleSpectrum.h then
-        local h = ((screenX - SettingsPanel._reticleSpectrum.x) / SettingsPanel._reticleSpectrum.w) * 360
-        local v = 1.0 - ((screenY - SettingsPanel._reticleSpectrum.y) / SettingsPanel._reticleSpectrum.h)
-        local s = 1.0
-
-        local r, g, b = hsvToRgb(h, s, v)
-
-        currentGraphicsSettings.reticle_color_rgb = {r, g, b, 1.0}
-        currentGraphicsSettings.reticle_color = nil
-        return true
-    end
-
-    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
-    local gw, gh = 700, 600
-    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
-    if screenX >= gx and screenX <= gx + gw and screenY >= gy and screenY <= gy + gh then
-        return true
-    end
-
-    return false
-end
-
-local function handleAccentGalleryClick(screenX, screenY)
-    if not accentGalleryOpen then
-        return false
-    end
-
-    if SettingsPanel._accentDone and screenX >= SettingsPanel._accentDone._rect.x and screenX <= SettingsPanel._accentDone._rect.x + SettingsPanel._accentDone._rect.w and
-       screenY >= SettingsPanel._accentDone._rect.y and screenY <= SettingsPanel._accentDone._rect.y + SettingsPanel._accentDone._rect.h then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        accentGalleryOpen = false
-        return true
-    end
-
-    if SettingsPanel._accentSpectrum and screenX >= SettingsPanel._accentSpectrum.x and screenX <= SettingsPanel._accentSpectrum.x + SettingsPanel._accentSpectrum.w and
-       screenY >= SettingsPanel._accentSpectrum.y and screenY <= SettingsPanel._accentSpectrum.y + SettingsPanel._accentSpectrum.h then
-        local h = ((screenX - SettingsPanel._accentSpectrum.x) / SettingsPanel._accentSpectrum.w) * 360
-        local v = 1.0 - ((screenY - SettingsPanel._accentSpectrum.y) / SettingsPanel._accentSpectrum.h)
-        local s = 1.0
-
-        local r, g, b = hsvToRgb(h, s, v)
-
-        accentColorSliders.r.value = r
-        accentColorSliders.g.value = g
-        accentColorSliders.b.value = b
-
-        currentGraphicsSettings.accent_theme = "Custom"
-        currentGraphicsSettings.accent_color_rgb = {r, g, b, 1.0}
-        applyCustomAccentColor(r, g, b)
-        return true
-    end
-
-    local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
-    local gw, gh = 600, 450
-    local gx, gy = (sw - gw) / 2, (sh - gh) / 2
-    if screenX >= gx and screenX <= gx + gw and screenY >= gy and screenY <= gy + gh then
-        return true
-    end
-
-    return false
-end
-
--- Slider hover tracking
-local hoveredSlider = {
-    master_volume = false,
-    sfx_volume = false,
-    music_volume = false
-}
-
-function SettingsPanel.calculateContentHeight()
-    -- If window/content bounds are available, compute contentHeight relative
-    -- to the current window so scrolling stays correct when the window is moved.
-    local contentX, contentY, contentW, contentH
-    if SettingsPanel.window then
-        local cb = SettingsPanel.window:getContentBounds()
-        contentX, contentY, contentW, contentH = cb.x, cb.y, cb.w, cb.h
-    else
-        local sw, sh = Viewport.getDimensions()
-        contentX, contentY, contentW, contentH = 0, 0, sw, sh
-    end
-
-    local yOffset = contentY + 10 + 60 -- start padding + initial offset
-    local itemHeight = 40
-
-    -- Graphics settings (vsync, max fps)
-    yOffset = yOffset + itemHeight * 2
-
-    -- UI Scale slider
-    yOffset = yOffset + itemHeight
-
-    -- Font Scale slider
-    yOffset = yOffset + itemHeight
-
-    -- Reticle button
-    yOffset = yOffset + itemHeight
-
-    -- Accent Color Theme
-    yOffset = yOffset + itemHeight
-
-    -- Helpers toggle
-    yOffset = yOffset + itemHeight
-
-    -- Audio settings section
-    yOffset = yOffset + itemHeight + 30 -- "Audio" label + spacing
-    yOffset = yOffset + itemHeight * 3 -- 3 volume sliders
-
-    -- Keybindings section
-    yOffset = yOffset + itemHeight + 30 -- "Keybindings" label + spacing
-    local keybindOrder = {
-        "toggle_inventory", "toggle_ship", "toggle_skills",
-        "toggle_map",
-        "hotbar_1", "hotbar_2", "hotbar_3", "hotbar_4", "hotbar_5", "hotbar_6", "hotbar_7"
-    }
-    yOffset = yOffset + 30 * #keybindOrder -- Each keybinding takes 30 pixels
-
-    -- Update scrollable content height based on last yOffset
-    -- The content height should be the total height of all content within the scissor area
-    contentHeight = (yOffset - contentY) + 20
-
-    -- Allow content to be taller than panel height for scrolling
-    -- The scrollbar will handle showing content that extends beyond the panel
-end
+local contentHeight = 0
 
 local function cloneSettings(src)
     return Util.deepCopy(src or {})
@@ -311,47 +51,40 @@ local function settingsEqual(a, b)
     return true
 end
 
-local function refreshGraphicsDropdowns()
-    if vsyncDropdown then
-        vsyncDropdown:setSelectedIndex(currentGraphicsSettings and currentGraphicsSettings.vsync and 2 or 1)
-    end
-    if fpsLimitDropdown and currentGraphicsSettings then
-        local fpsToIndex = {
-            [0] = 1,
-            [30] = 2,
-            [60] = 3,
-            [120] = 4,
-            [144] = 5,
-            [240] = 6
-        }
-        local idx = fpsToIndex[currentGraphicsSettings.max_fps or 60] or 3
-        currentGraphicsSettings.max_fps_index = idx
-        fpsLimitDropdown:setSelectedIndex(idx)
-    end
-    if accentThemeDropdown and currentGraphicsSettings then
-        local accentThemes = {
-            Strings.getTheme("cyan_lavender"),
-            Strings.getTheme("blue_purple"),
-            Strings.getTheme("green_emerald"),
-            Strings.getTheme("red_orange"),
-            Strings.getTheme("monochrome")
-        }
-        local themeIndex = 1
-        for i, theme in ipairs(accentThemes) do
-            if theme == (currentGraphicsSettings.accent_theme or Strings.getTheme("cyan_lavender")) then
-                themeIndex = i
-                break
-            end
-        end
-        accentThemeDropdown:setSelectedIndex(themeIndex)
-    end
+local function updateModuleData()
+    GraphicsPanel.setSettings(currentGraphicsSettings)
+    AudioPanel.setSettings(currentAudioSettings)
+    ControlsPanel.setKeymap(keymap, function(newMap)
+        keymap = newMap
+    end)
+    GraphicsPanel.refreshDropdowns()
 end
 
 function SettingsPanel.refreshFromSettings()
     currentGraphicsSettings = cloneSettings(Settings.getGraphicsSettings())
     currentAudioSettings = cloneSettings(Settings.getAudioSettings())
-    refreshGraphicsDropdowns()
-    keymap = cloneSettings(Settings.getKeymap() or {})
+    keymap = cloneSettings(Settings.getKeymap())
+    updateModuleData()
+end
+
+function SettingsPanel.calculateContentHeight()
+    if not SettingsPanel.window then
+        contentHeight = 0
+        return
+    end
+
+    local content = SettingsPanel.window:getContentBounds()
+    local baseY = content.y + 10
+    local itemHeight = 40
+    local sectionSpacing = 60
+
+    local graphicsEnd = GraphicsPanel.getContentHeight(baseY, itemHeight)
+    local audioBase = graphicsEnd + sectionSpacing
+    local audioEnd = AudioPanel.getContentHeight(audioBase)
+    local controlsBase = audioEnd + sectionSpacing
+    local controlsEnd = ControlsPanel.getContentHeight(controlsBase)
+
+    contentHeight = (controlsEnd - content.y) + 20
 end
 
 function SettingsPanel.init()
@@ -374,358 +107,70 @@ function SettingsPanel.init()
     SettingsPanel.refreshFromSettings()
     originalGraphicsSettings = cloneSettings(Settings.getGraphicsSettings())
     originalAudioSettings = cloneSettings(Settings.getAudioSettings())
-    if not currentGraphicsSettings.reticle_style then
-        currentGraphicsSettings.reticle_style = 1
-    end
-    keymap = Settings.getKeymap()
-
-    -- Load resolutions early
-    resolutions = Settings.getAvailableResolutions()
-    -- Find the index of the current resolution
-    selectedResolutionIndex = 1 -- Default
-    for i, res in ipairs(resolutions) do
-        if res.width == currentGraphicsSettings.resolution.width and res.height == currentGraphicsSettings.resolution.height then
-            selectedResolutionIndex = i
-            break
-        end
-    end
-
-    -- Find the index of the current fullscreen type
-    if currentGraphicsSettings.fullscreen then
-        selectedFullscreenTypeIndex = 2 -- fullscreen
-    else
-        selectedFullscreenTypeIndex = 1 -- windowed
-    end
-
-
-    -- Apply the current accent theme or custom color
-    if currentGraphicsSettings.accent_color_rgb and currentGraphicsSettings.accent_theme == "Custom" then
-        local rgb = currentGraphicsSettings.accent_color_rgb
-        accentColorSliders.r.value = rgb[1] or 0.7
-        accentColorSliders.g.value = rgb[2] or 0.7
-        accentColorSliders.b.value = rgb[3] or 0.7
-        applyCustomAccentColor(accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value)
-    else
-        applyAccentTheme(currentGraphicsSettings.accent_theme or "Monochrome")
-    end
-
-    -- Initialize standardized dropdown components
-    local valueX = 150
-    local itemHeight = 40
-
-    -- VSync dropdown
-    vsyncDropdown = Dropdown.new({
-        x = valueX,
-        y = 60,
-        options = vsyncTypes,
-        selectedIndex = currentGraphicsSettings.vsync and 2 or 1,
-        onSelect = function(index)
-            currentGraphicsSettings.vsync = (index == 2)
-        end
-    })
-
-    -- FPS Limit dropdown
-    fpsLimitDropdown = Dropdown.new({
-        x = valueX,
-        y = 60 + itemHeight,
-        options = fpsLimitTypes,
-        selectedIndex = currentGraphicsSettings.max_fps_index or 3,
-        onSelect = function(index)
-            currentGraphicsSettings.max_fps_index = index
-            local fpsMap = {
-                [1] = 0,
-                [2] = 30,
-                [3] = 60,
-                [4] = 120,
-                [5] = 144,
-                [6] = 240
-            }
-            currentGraphicsSettings.max_fps = fpsMap[index] or 60
-        end
-    })
-
-    -- Accent Theme dropdown
-    local accentThemes = {
-        Strings.getTheme("cyan_lavender"),
-        Strings.getTheme("blue_purple"),
-        Strings.getTheme("green_emerald"),
-        Strings.getTheme("red_orange"),
-        Strings.getTheme("monochrome")
-    }
-    local themeIndex = 1
-    for i, theme in ipairs(accentThemes) do
-        if theme == (currentGraphicsSettings.accent_theme or "Monochrome") then
-            themeIndex = i
-            break
-        end
-    end
-
-    -- Color picker button (replaces dropdown)
-    -- We'll handle this in the drawing and mouse handling code
 end
 
 function SettingsPanel.update(dt)
     if not SettingsPanel.visible then return end
-    -- Update logic for the settings panel
 end
 
 function SettingsPanel.draw()
     if not SettingsPanel.visible then return end
-
     SettingsPanel.window:draw()
 end
 
-function SettingsPanel.drawContent(window, x, y, w, h)
-    -- Set a consistent font for the entire settings panel
+local function drawSections(window, x, y, w, h)
     local settingsFont = Theme.fonts and (Theme.fonts.small or Theme.fonts.normal) or love.graphics.getFont()
     love.graphics.setFont(settingsFont)
 
     local mx, my = Viewport.getMousePosition()
     local scrolledMouseY = my + scrollY
 
-    love.graphics.push()
-    -- Get the actual content bounds from the window (accounts for title bar and bottom bar)
     local content = window:getContentBounds()
     local innerTop = content.y
     local innerH = content.h
+
+    love.graphics.push()
     love.graphics.setScissor(content.x, innerTop, content.w, innerH)
     love.graphics.translate(0, -scrollY)
 
-    -- Settings content with organized sections
     local pad = (Theme.ui and Theme.ui.contentPadding) or 20
-    local yOffset = innerTop + 10  -- Start from the scissor area top with small padding
-    local labelX = x + pad
-    local valueX = x + 150
-    local dropdownW = 150
-    local itemHeight = 40
-    local sectionSpacing = 60  -- Space between sections
-
-    -- === GRAPHICS SECTION ===
-    Theme.setColor(Theme.colors.accent)
-    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
-    love.graphics.print("Graphics Settings", labelX, yOffset)
-    love.graphics.setFont(settingsFont)
-    yOffset = yOffset + 30
-
-    -- VSync
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("VSync:", labelX, yOffset)
-    vsyncDropdown:setPosition(valueX, yOffset - 2 - scrollY)
-    yOffset = yOffset + itemHeight
-
-    -- Max FPS
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Max FPS:", labelX, yOffset)
-    fpsLimitDropdown:setPosition(valueX, yOffset - 2 - scrollY)
-    yOffset = yOffset + itemHeight
-
-    -- Show FPS Toggle
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Show FPS:", labelX, yOffset)
-    local showFpsToggleX = valueX
-    local showFpsToggleY = yOffset - 4
-    local showFpsToggleW = 60
-    local showFpsToggleH = 26
-    local showFpsToggleHover = mx >= showFpsToggleX and mx <= showFpsToggleX + showFpsToggleW and scrolledMouseY >= showFpsToggleY and scrolledMouseY <= showFpsToggleY + showFpsToggleH
-    local showFpsToggleActive = currentGraphicsSettings.show_fps or false
-    Theme.drawStyledButton(showFpsToggleX, showFpsToggleY, showFpsToggleW, showFpsToggleH, showFpsToggleActive and "ON" or "OFF", showFpsToggleHover, love.timer.getTime())
-    SettingsPanel._showFpsToggleRect = { x = showFpsToggleX, y = showFpsToggleY - scrollY, w = showFpsToggleW, h = showFpsToggleH }
-    yOffset = yOffset + itemHeight
-
-    -- Cursor popup trigger, current preview, and color dropdown
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Cursor:", labelX, yOffset)
-    local btnX, btnY, btnW, btnH = valueX, yOffset - 4, 140, 26
-    local btnHover = mx >= btnX and mx <= btnX + btnW and scrolledMouseY >= btnY and scrolledMouseY <= btnY + btnH
-    -- Show full text without truncation
-    Theme.drawStyledButton(btnX, btnY, btnW, btnH, "Select Cursor", btnHover, love.timer.getTime())
-    SettingsPanel._reticleButtonRect = { x = btnX, y = btnY - scrollY, w = btnW, h = btnH }
-    -- Preview next to button (same height as button)
-    local previewSize = btnH
-    local pvX, pvY = btnX + btnW + 10, btnY
-    Theme.drawGradientGlowRect(pvX, pvY, previewSize, previewSize, 3, Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
-    love.graphics.push()
-    love.graphics.translate(pvX + previewSize * 0.5, pvY + previewSize * 0.5)
-    local styleIndex = math.max(1, math.min(50, currentGraphicsSettings.reticle_style or 1))
-    local pointerScale = 0.9 + (styleIndex - 1) / 49 * 0.6
-    local baseScale = (previewSize / 32) * 0.95
-    love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
-    -- Simple reticle preview
-    Theme.setColor(Theme.colors.textHighlight)
-    love.graphics.setLineWidth(1)
-    love.graphics.line(-8, 0, 8, 0)
-    love.graphics.line(0, -8, 0, 8)
-    love.graphics.circle('fill', 0, 0, 1)
-    love.graphics.pop()
-    yOffset = yOffset + itemHeight
-
-    -- Accent Color Gallery
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Accent Color:", labelX, yOffset)
-    
-    -- Gallery button
-    local btnX, btnY, btnW, btnH = valueX, yOffset - 4, 140, 26
-    local btnHover = mx >= btnX and mx <= btnX + btnW and scrolledMouseY >= btnY and scrolledMouseY <= btnY + btnH
-    Theme.drawStyledButton(btnX, btnY, btnW, btnH, "Select Accent", btnHover, love.timer.getTime())
-    SettingsPanel._accentButtonRect = { x = btnX, y = btnY - scrollY, w = btnW, h = btnH }
-    
-    -- Preview next to button (same height as button)
-    local previewSize = btnH
-    local pvX, pvY = btnX + btnW + 10, btnY
-    Theme.drawGradientGlowRect(pvX, pvY, previewSize, previewSize, 3, Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
-    
-    -- Draw current accent color preview
-    local currentTheme = currentGraphicsSettings.accent_theme or "Monochrome"
-    local previewColor = Theme.colors.accent
-    if currentTheme == "Custom" and currentGraphicsSettings.accent_color_rgb then
-        previewColor = currentGraphicsSettings.accent_color_rgb
-    end
-    
-    Theme.setColor(previewColor)
-    love.graphics.rectangle("fill", pvX + 2, pvY + 2, previewSize - 4, previewSize - 4)
-    
-    -- Draw accent theme name
-    Theme.setColor(Theme.colors.text)
-    local themeText = currentTheme
-    local themeTextX = pvX + previewSize + 10
-    local themeTextY = pvY + (previewSize - Theme.fonts.medium:getHeight()) / 2
-    love.graphics.print(themeText, themeTextX, themeTextY)
-    
-    yOffset = yOffset + itemHeight
-
-
-    -- === AUDIO SECTION ===
-    Theme.setColor(Theme.colors.accent)
-    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
-    love.graphics.print("Audio Settings", labelX, yOffset)
-    love.graphics.setFont(settingsFont)
-    yOffset = yOffset + 30
-
-    -- Master Volume
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Master Volume:", labelX, yOffset)
-    local masterVolumeText = string.format("%.2f", currentAudioSettings.master_volume)
-    love.graphics.print(masterVolumeText, x + 400, yOffset)
-    local masterSliderX = valueX
-    local masterSliderW = 200
-    local masterHandleX = masterSliderX + (masterSliderW - 10) * currentAudioSettings.master_volume
-
-    -- Draw slider track with hover effect
-    local masterSliderTrackColor = hoveredSlider.master_volume and Theme.colors.textHighlight or Theme.colors.bg3
-    local masterSliderTrackGlow = hoveredSlider.master_volume and Theme.effects.glowWeak * 0.3 or Theme.effects.glowWeak * 0.1
-    Theme.drawGradientGlowRect(masterSliderX, yOffset - 5, masterSliderW, 10, 2, masterSliderTrackColor, Theme.colors.bg2, Theme.colors.border, masterSliderTrackGlow)
-
-    -- Draw slider handle with hover effect
-    local masterHandleColor = hoveredSlider.master_volume and Theme.colors.accentGold or Theme.colors.accent
-    local masterHandleGlow = hoveredSlider.master_volume and Theme.effects.glowWeak * 0.4 or Theme.effects.glowWeak * 0.2
-    Theme.drawGradientGlowRect(masterHandleX, yOffset - 7.5, 10, 15, 2, masterHandleColor, Theme.colors.bg3, Theme.colors.border, masterHandleGlow)
-    yOffset = yOffset + itemHeight
-
-    -- SFX Volume
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("SFX Volume:", labelX, yOffset)
-    local sfxVolumeText = string.format("%.2f", currentAudioSettings.sfx_volume)
-    love.graphics.print(sfxVolumeText, x + 400, yOffset)
-    local sfxSliderX = valueX
-    local sfxSliderW = 200
-    local sfxHandleX = sfxSliderX + (sfxSliderW - 10) * currentAudioSettings.sfx_volume
-
-    -- Draw slider track with hover effect
-    local sfxSliderTrackColor = hoveredSlider.sfx_volume and Theme.colors.textHighlight or Theme.colors.bg3
-    local sfxSliderTrackGlow = hoveredSlider.sfx_volume and Theme.effects.glowWeak * 0.3 or Theme.effects.glowWeak * 0.1
-    Theme.drawGradientGlowRect(sfxSliderX, yOffset - 5, sfxSliderW, 10, 2, sfxSliderTrackColor, Theme.colors.bg2, Theme.colors.border, sfxSliderTrackGlow)
-
-    -- Draw slider handle with hover effect
-    local sfxHandleColor = hoveredSlider.sfx_volume and Theme.colors.accentGold or Theme.colors.accent
-    local sfxHandleGlow = hoveredSlider.sfx_volume and Theme.effects.glowWeak * 0.4 or Theme.effects.glowWeak * 0.2
-    Theme.drawGradientGlowRect(sfxHandleX, yOffset - 7.5, 10, 15, 2, sfxHandleColor, Theme.colors.bg3, Theme.colors.border, sfxHandleGlow)
-    yOffset = yOffset + itemHeight
-
-    -- Music Volume
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Music Volume:", labelX, yOffset)
-    local musicVolumeText = string.format("%.2f", currentAudioSettings.music_volume)
-    love.graphics.print(musicVolumeText, x + 400, yOffset)
-    local musicSliderX = valueX
-    local musicSliderW = 200
-    local musicHandleX = musicSliderX + (musicSliderW - 10) * currentAudioSettings.music_volume
-
-    -- Draw slider track with hover effect
-    local musicSliderTrackColor = hoveredSlider.music_volume and Theme.colors.textHighlight or Theme.colors.bg3
-    local musicSliderTrackGlow = hoveredSlider.music_volume and Theme.effects.glowWeak * 0.3 or Theme.effects.glowWeak * 0.1
-    Theme.drawGradientGlowRect(musicSliderX, yOffset - 5, musicSliderW, 10, 2, musicSliderTrackColor, Theme.colors.bg2, Theme.colors.border, musicSliderTrackGlow)
-
-    -- Draw slider handle with hover effect
-    local musicHandleColor = hoveredSlider.music_volume and Theme.colors.accentGold or Theme.colors.accent
-    local musicHandleGlow = hoveredSlider.music_volume and Theme.effects.glowWeak * 0.4 or Theme.effects.glowWeak * 0.2
-    Theme.drawGradientGlowRect(musicHandleX, yOffset - 7.5, 10, 15, 2, musicHandleColor, Theme.colors.bg3, Theme.colors.border, musicHandleGlow)
-    yOffset = yOffset + itemHeight + sectionSpacing
-
-    -- === CONTROLS SECTION ===
-    Theme.setColor(Theme.colors.accent)
-    love.graphics.setFont(Theme.fonts and (Theme.fonts.normal or Theme.fonts.small) or love.graphics.getFont())
-    love.graphics.print("Controls", x + 20, yOffset)
-    love.graphics.setFont(settingsFont)
-    yOffset = yOffset + 30
-
-    -- Keybindings
-    Theme.setColor(Theme.colors.text)
-    love.graphics.print("Keybindings", labelX, yOffset)
-    love.graphics.print("(Click to change)", labelX + 130, yOffset + 2)
-    yOffset = yOffset + 30
-    
-    -- Use consistent order for keybindings
-    local keybindOrder = {
-        "toggle_inventory", "toggle_ship", "toggle_skills",
-        "toggle_map",
-        "hotbar_1", "hotbar_2", "hotbar_3", "hotbar_4", "hotbar_5", "hotbar_6", "hotbar_7"
+    local yOffset = innerTop + 10
+    local layout = {
+        x = x,
+        y = y,
+        w = w,
+        h = h,
+        labelX = x + pad,
+        valueX = x + 150,
+        itemHeight = 40,
+        scrollY = scrollY,
+        settingsFont = settingsFont,
+        mx = mx,
+        my = my,
+        scrolledMouseY = scrolledMouseY,
+        yOffset = yOffset
     }
-    
-    for _, action in ipairs(keybindOrder) do
-        local key = keymap[action]
-        Theme.setColor(Theme.colors.text)
-        love.graphics.print(action, x + 20, yOffset)
-        
-        if key then
-            -- Draw keybinding as a button
-            local btnX, btnY, btnW, btnH = x + 200, yOffset - 2, 100, 24
-            local keyText = bindingAction == action and Strings.getControl("press_key") or key
-            local hover = mx >= btnX and mx <= btnX + btnW and scrolledMouseY >= btnY and scrolledMouseY <= btnY + btnH
-            
-            -- Use themed button drawing with compact option for smaller font
-            Theme.drawStyledButton(btnX, btnY, btnW, btnH, keyText, hover, love.timer.getTime(), nil, bindingAction == action, { compact = true })
-        else
-            -- Show "Not Set" if no key is configured
-            Theme.setColor(Theme.colors.textDisabled)
-            love.graphics.print("Not Set", x + 200, yOffset)
-        end
-        
-        yOffset = yOffset + 30
-    end
 
-    -- Calculate content height
-    SettingsPanel.calculateContentHeight()
+    layout.yOffset = GraphicsPanel.draw(layout)
+    layout.yOffset = layout.yOffset + 60
+    layout.yOffset = AudioPanel.draw(layout)
+    layout.yOffset = layout.yOffset + 60
+    ControlsPanel.draw(layout)
 
-    love.graphics.pop() -- End of scrollable content translation
-
-    -- Disable scissor for UI elements below the scrollable area
+    love.graphics.pop()
     love.graphics.setScissor()
 
-    -- Draw separation lines between sections
-    Theme.setColor(Theme.colors.border)
-    love.graphics.setLineWidth(1)
-    
-    -- Bottom separation line (between content and bottom bar)
-    local content = SettingsPanel.window:getContentBounds()
-    local bottomBarY = content.y + content.h
-    love.graphics.line(x, bottomBarY, x + w, bottomBarY)
+    SettingsPanel.calculateContentHeight()
 
-    -- Set scissor to full panel bounds for dropdowns and apply button
-    love.graphics.setScissor(x, y, w, h)
+    return content, mx, my
+end
 
-    -- Scrollbar (inside scissor, but not translated)
+local function drawScrollbar(content, x, y, w, h)
+    local innerTop = content.y
+    local innerH = content.h
+
     local scrollbarWidth = 12
-    local scrollbarX = x + w - scrollbarWidth - 4  -- 4px margin from right edge
+    local scrollbarX = x + w - scrollbarWidth - 4
     local scrollbarY = innerTop
     local scrollbarH = innerH
     if contentHeight > innerH then
@@ -733,328 +178,66 @@ function SettingsPanel.drawContent(window, x, y, w, h)
         local trackRange = scrollbarH - thumbH
         local thumbY = scrollbarY + (trackRange > 0 and (trackRange * (scrollY / (contentHeight - innerH))) or 0)
 
-        -- Draw scrollbar track (background) - solid black with border
         Theme.setColor(Theme.colors.bg0)
         love.graphics.rectangle("fill", scrollbarX, scrollbarY, scrollbarWidth, scrollbarH)
         Theme.setColor(Theme.colors.border)
         love.graphics.rectangle("line", scrollbarX, scrollbarY, scrollbarWidth, scrollbarH)
-        
-        -- Draw scrollbar thumb (handle) - accent color with border
+
         Theme.setColor(Theme.colors.accent)
         love.graphics.rectangle("fill", scrollbarX + 1, thumbY + 1, scrollbarWidth - 2, thumbH - 2)
         Theme.setColor(Theme.colors.border)
         love.graphics.rectangle("line", scrollbarX + 1, thumbY + 1, scrollbarWidth - 2, thumbH - 2)
 
-        -- Store scrollbar bounds for mouse interaction (convert to screen coordinates)
-        local windowX, windowY = 0, 0
-        if SettingsPanel.window then
-            windowX, windowY = SettingsPanel.window.x, SettingsPanel.window.y
-        end
-        SettingsPanel._scrollbarTrack = { x = scrollbarX + windowX, y = scrollbarY + windowY, w = scrollbarWidth, h = scrollbarH }
-        SettingsPanel._scrollbarThumb = { x = scrollbarX + windowX, y = thumbY + windowY, w = scrollbarWidth, h = thumbH }
+        SettingsPanel._scrollbarTrack = { x = scrollbarX, y = scrollbarY, w = scrollbarWidth, h = scrollbarH }
+        SettingsPanel._scrollbarThumb = { x = scrollbarX, y = thumbY, w = scrollbarWidth, h = thumbH }
     else
         SettingsPanel._scrollbarTrack = nil
         SettingsPanel._scrollbarThumb = nil
     end
+end
 
-    -- Draw dropdowns within the normal scissor context (they now respect clipping)
-    -- First draw all dropdown buttons (for proper z-ordering)
-    vsyncDropdown:drawButtonOnly(mx, my)
-    fpsLimitDropdown:drawButtonOnly(mx, my)
+function SettingsPanel.drawContent(window, x, y, w, h)
+    local content, mx, my = drawSections(window, x, y, w, h)
 
-    -- Then draw options for any open dropdowns (on top)
-    vsyncDropdown:drawOptionsOnly(mx, my)
-    fpsLimitDropdown:drawOptionsOnly(mx, my)
+    local settingsFont = Theme.fonts and (Theme.fonts.small or Theme.fonts.normal) or love.graphics.getFont()
+    love.graphics.setFont(settingsFont)
 
-    -- Disable scissor for buttons (they're in the bottom bar area)
+    drawScrollbar(content, x, y, w, h)
+
+    love.graphics.setScissor(x, y, w, h)
+    if GraphicsPanel.drawForeground then
+        GraphicsPanel.drawForeground(mx, my)
+    end
     love.graphics.setScissor()
 
-    -- Apply and Reset buttons
+    if GraphicsPanel.drawOverlays then
+        GraphicsPanel.drawOverlays()
+    end
+
     local buttonW, buttonH = 100, 30
     local buttonSpacing = 20
     local totalButtonWidth = buttonW * 2 + buttonSpacing
-    local applyButtonX = x + (w / 2) - totalButtonWidth / 2
+    local applyButtonX = content.x + (content.w / 2) - totalButtonWidth / 2
     local resetButtonX = applyButtonX + buttonW + buttonSpacing
-    local buttonAreaY = content.y + content.h
-    local buttonY = buttonAreaY + 15
-    local applyBtnHover = mx >= applyButtonX and mx <= applyButtonX + buttonW and my >= buttonY and my <= buttonY + buttonH
-    local resetBtnHover = mx >= resetButtonX and mx <= resetButtonX + buttonW and my >= buttonY and my <= buttonY + buttonH
+    local buttonY = content.y + content.h + 15
+    local applyHover = mx >= applyButtonX and mx <= applyButtonX + buttonW and my >= buttonY and my <= buttonY + buttonH
+    local resetHover = mx >= resetButtonX and mx <= resetButtonX + buttonW and my >= buttonY and my <= buttonY + buttonH
 
-    -- Draw Apply button with green styling
-    local applyText = Strings.getUI("apply_button")
-    Theme.drawStyledButton(applyButtonX, buttonY, buttonW, buttonH, applyText, applyBtnHover, love.timer.getTime(), {0.2, 0.8, 0.2, 1.0})
+    Theme.drawStyledButton(applyButtonX, buttonY, buttonW, buttonH, Strings.getUI("apply_button"), applyHover, love.timer.getTime(), {0.2, 0.8, 0.2, 1.0})
     SettingsPanel._applyButton = { _rect = { x = applyButtonX, y = buttonY, w = buttonW, h = buttonH } }
 
-    -- Draw Reset button with red styling
-    local resetText = "Reset"
-    Theme.drawStyledButton(resetButtonX, buttonY, buttonW, buttonH, resetText, resetBtnHover, love.timer.getTime(), {0.8, 0.2, 0.2, 1.0})
+    Theme.drawStyledButton(resetButtonX, buttonY, buttonW, buttonH, "Reset", resetHover, love.timer.getTime(), {0.8, 0.2, 0.2, 1.0})
     SettingsPanel._resetButton = { _rect = { x = resetButtonX, y = buttonY, w = buttonW, h = buttonH } }
+end
 
-
-    -- Reticle Gallery Popup
-    if reticleGalleryOpen then
-        local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
-        local gw, gh = 700, 600
-        local gx, gy = (sw - gw) / 2, (sh - gh) / 2
-        Theme.drawGradientGlowRect(gx, gy, gw, gh, 6, Theme.colors.bg1, Theme.colors.bg0, Theme.colors.accent, Theme.effects.glowWeak)
-        Theme.drawEVEBorder(gx, gy, gw, gh, 6, Theme.colors.border, 8)
-        Theme.setColor(Theme.colors.textHighlight)
-        love.graphics.print(Strings.getUI("choose_reticle"), gx + 16, gy + 12)
-        -- Color picker with spectrum (same as accent color picker)
-        local pickerY = gy + 50
-        local pickerX = gx + 20
-        local pickerSize = 200
-        local previewSize = 80
-        
-        -- Determine current color (RGB)
-        local function getCurrentRGB()
-          local c = currentGraphicsSettings.reticle_color_rgb
-          if c and type(c) == 'table' then return c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1 end
-          local ThemeMod = require('src.core.theme')
-          local name = currentGraphicsSettings.reticle_color or 'accent'
-          local map = {
-            accent = ThemeMod.colors.accent,
-            white = {1,1,1,1},
-            cyan = ThemeMod.colors.info,
-            green = ThemeMod.colors.success,
-            red = ThemeMod.colors.danger,
-            yellow = ThemeMod.colors.warning,
-            magenta = ThemeMod.colors.accentPink,
-            teal = ThemeMod.colors.accentTeal,
-            gold = ThemeMod.colors.accentGold,
-          }
-          local cc = map[(name or 'accent'):lower()] or ThemeMod.colors.accent
-          return cc[1], cc[2], cc[3], cc[4] or 1
-        end
-        local cr, cg, cb, ca = getCurrentRGB()
-        
-        -- Color spectrum (HSV-based color picker)
-        local spectrumX = pickerX
-        local spectrumY = pickerY
-        local spectrumW = pickerSize
-        local spectrumH = pickerSize
-        
-        -- Draw color spectrum
-        for x = 0, spectrumW - 1 do
-            for y = 0, spectrumH - 1 do
-                local h = (x / spectrumW) * 360  -- Hue: 0-360
-                local s = 1.0  -- Saturation: 1.0 (full saturation)
-                local v = 1.0 - (y / spectrumH)  -- Value: 1.0 to 0.0 (top to bottom)
-                
-                -- Convert HSV to RGB
-                local r, g, b = hsvToRgb(h, s, v)
-                
-                Theme.setColor({r, g, b, 1})
-                love.graphics.rectangle("fill", spectrumX + x, spectrumY + y, 1, 1)
-            end
-        end
-        
-        -- Draw spectrum border
-        Theme.setColor(Theme.colors.border)
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", spectrumX, spectrumY, spectrumW, spectrumH)
-        
-        -- Draw current color indicator (crosshair)
-        local currentH = rgbToHsv(cr, cg, cb)
-        local indicatorX = spectrumX + (currentH.h / 360) * spectrumW
-        local indicatorY = spectrumY + (1 - currentH.v) * spectrumH
-        
-        -- Draw crosshair
-        Theme.setColor({1, 1, 1, 1})
-        love.graphics.setLineWidth(2)
-        love.graphics.line(indicatorX - 8, indicatorY, indicatorX + 8, indicatorY)
-        love.graphics.line(indicatorX, indicatorY - 8, indicatorX, indicatorY + 8)
-        
-        -- Draw crosshair border
-        Theme.setColor({0, 0, 0, 1})
-        love.graphics.setLineWidth(1)
-        love.graphics.line(indicatorX - 9, indicatorY, indicatorX + 9, indicatorY)
-        love.graphics.line(indicatorX, indicatorY - 9, indicatorX, indicatorY + 9)
-        
-        -- Store spectrum bounds for click detection
-        SettingsPanel._reticleSpectrum = { x = spectrumX, y = spectrumY, w = spectrumW, h = spectrumH }
-        
-        -- Color preview box
-        local previewX = pickerX + pickerSize + 20
-        local previewY = pickerY
-        Theme.setColor({cr, cg, cb, 1})
-        love.graphics.rectangle("fill", previewX, previewY, previewSize, previewSize)
-        Theme.setColor(Theme.colors.border)
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", previewX, previewY, previewSize, previewSize)
-        
-        -- Draw "Cursor Color" label above preview
-        Theme.setColor(Theme.colors.text)
-        local labelText = "Cursor Color"
-        local labelW = Theme.fonts.small:getWidth(labelText)
-        love.graphics.print(labelText, previewX + (previewSize - labelW) / 2, previewY - 20)
-        
-        -- RGB values display
-        local rgbY = previewY + previewSize + 10
-        Theme.setColor(Theme.colors.text)
-        local rgbText = string.format("R: %d  G: %d  B: %d", 
-            math.floor(cr * 255), 
-            math.floor(cg * 255), 
-            math.floor(cb * 255))
-        love.graphics.print(rgbText, previewX, rgbY)
-        
-        -- HSV values display
-        local hsvY = rgbY + 15
-        local hsvText = string.format("H: %d°  S: %d%%  V: %d%%", 
-            math.floor(currentH.h), 
-            math.floor(currentH.s * 100), 
-            math.floor(currentH.v * 100))
-        love.graphics.print(hsvText, previewX, hsvY)
-        -- Gallery (positioned below the color picker)
-        local px, py = gx + 16, pickerY + pickerSize + 20
-        local cols, cell, gap = 10, 44, 8
-        local total, rows = 50, math.ceil(50/cols)
-        SettingsPanel._reticlePopup = { x = px, y = py, cols = cols, rows = rows, cell = cell, gap = gap }
-        local curStyle = currentGraphicsSettings.reticle_style or 1
-        for i = 1, total do
-            local r = math.floor((i-1)/cols)
-            local c = (i-1) % cols
-            local cx = px + c * (cell + gap)
-            local cy = py + r * (cell + gap)
-            local isSel = (i == curStyle)
-            Theme.drawGradientGlowRect(cx, cy, cell, cell, 3, isSel and Theme.colors.bg3 or Theme.colors.bg2, Theme.colors.bg1, Theme.colors.border, Theme.effects.glowWeak * 0.1)
-            love.graphics.push()
-            love.graphics.translate(cx + cell * 0.5, cy + cell * 0.5)
-            local pointerScale = 0.9 + (i - 1) / 49 * 0.6
-            local baseScale = (cell / 32) * 0.95
-            love.graphics.scale(baseScale * pointerScale, baseScale * pointerScale)
-            -- Simple reticle preview
-            Theme.setColor({cr, cg, cb, 1})
-            love.graphics.setLineWidth(1)
-            love.graphics.line(-8, 0, 8, 0)
-            love.graphics.line(0, -8, 0, 8)
-            love.graphics.circle('fill', 0, 0, 1)
-            love.graphics.pop()
-        end
-        -- Done button
-        local doneW, doneH = 90, 28
-        local doneX, doneY = gx + gw - doneW - 16, gy + gh - doneH - 12
-        local mx, my = Viewport.getMousePosition()
-        local doneHover = mx >= doneX and mx <= doneX + doneW and my >= doneY and my <= doneY + doneH
-        Theme.drawStyledButton(doneX, doneY, doneW, doneH, Strings.getUI("done_button"), doneHover, love.timer.getTime())
-        SettingsPanel._reticleDone = { _rect = { x = doneX, y = doneY, w = doneW, h = doneH } }
-    else
-        SettingsPanel._reticlePopup = nil
-        SettingsPanel._reticleDone = nil
-    end
-
-    -- Accent Color Gallery Popup
-    if accentGalleryOpen then
-        local sw, sh = love.graphics.getWidth(), love.graphics.getHeight()
-        local gw, gh = 600, 450
-        local gx, gy = (sw - gw) / 2, (sh - gh) / 2
-        Theme.drawGradientGlowRect(gx, gy, gw, gh, 6, Theme.colors.bg1, Theme.colors.bg0, Theme.colors.accent, Theme.effects.glowWeak)
-        Theme.drawEVEBorder(gx, gy, gw, gh, 6, Theme.colors.border, 8)
-        Theme.setColor(Theme.colors.textHighlight)
-        love.graphics.print("Choose Accent Theme", gx + 16, gy + 12)
-        
-        -- Color picker with spectrum
-        local pickerY = gy + 50
-        local pickerX = gx + 20
-        local pickerSize = 200
-        local previewSize = 80
-        
-        -- Get current custom color
-        local cr, cg, cb = accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value
-        if currentGraphicsSettings.accent_color_rgb then
-            cr, cg, cb = currentGraphicsSettings.accent_color_rgb[1], currentGraphicsSettings.accent_color_rgb[2], currentGraphicsSettings.accent_color_rgb[3]
-        end
-        
-        -- Color spectrum (HSV-based color picker)
-        local spectrumX = pickerX
-        local spectrumY = pickerY
-        local spectrumW = pickerSize
-        local spectrumH = pickerSize
-        
-        -- Draw color spectrum
-        for x = 0, spectrumW - 1 do
-            for y = 0, spectrumH - 1 do
-                local h = (x / spectrumW) * 360  -- Hue: 0-360
-                local s = 1.0  -- Saturation: 1.0 (full saturation)
-                local v = 1.0 - (y / spectrumH)  -- Value: 1.0 to 0.0 (top to bottom)
-                
-                -- Convert HSV to RGB
-                local r, g, b = hsvToRgb(h, s, v)
-                
-                Theme.setColor({r, g, b, 1})
-                love.graphics.rectangle("fill", spectrumX + x, spectrumY + y, 1, 1)
-            end
-        end
-        
-        -- Draw spectrum border
-        Theme.setColor(Theme.colors.border)
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", spectrumX, spectrumY, spectrumW, spectrumH)
-        
-        -- Draw current color indicator (crosshair)
-        local currentH = rgbToHsv(cr, cg, cb)
-        local indicatorX = spectrumX + (currentH.h / 360) * spectrumW
-        local indicatorY = spectrumY + (1 - currentH.v) * spectrumH
-        
-        -- Draw crosshair
-        Theme.setColor({1, 1, 1, 1})
-        love.graphics.setLineWidth(2)
-        love.graphics.line(indicatorX - 8, indicatorY, indicatorX + 8, indicatorY)
-        love.graphics.line(indicatorX, indicatorY - 8, indicatorX, indicatorY + 8)
-        
-        -- Draw crosshair border
-        Theme.setColor({0, 0, 0, 1})
-        love.graphics.setLineWidth(1)
-        love.graphics.line(indicatorX - 9, indicatorY, indicatorX + 9, indicatorY)
-        love.graphics.line(indicatorX, indicatorY - 9, indicatorX, indicatorY + 9)
-        
-        -- Store spectrum bounds for click detection
-        SettingsPanel._accentSpectrum = { x = spectrumX, y = spectrumY, w = spectrumW, h = spectrumH }
-        
-        -- Color preview box
-        local previewX = pickerX + pickerSize + 20
-        local previewY = pickerY
-        Theme.setColor({cr, cg, cb, 1})
-        love.graphics.rectangle("fill", previewX, previewY, previewSize, previewSize)
-        Theme.setColor(Theme.colors.border)
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", previewX, previewY, previewSize, previewSize)
-        
-        -- Draw "Custom Color" label above preview
-        Theme.setColor(Theme.colors.text)
-        local labelText = "Custom Color"
-        local labelW = Theme.fonts.small:getWidth(labelText)
-        love.graphics.print(labelText, previewX + (previewSize - labelW) / 2, previewY - 20)
-        
-        -- RGB values display
-        local rgbY = previewY + previewSize + 10
-        Theme.setColor(Theme.colors.text)
-        local rgbText = string.format("R: %d  G: %d  B: %d", 
-            math.floor(cr * 255), 
-            math.floor(cg * 255), 
-            math.floor(cb * 255))
-        love.graphics.print(rgbText, previewX, rgbY)
-        
-        -- HSV values display
-        local hsvY = rgbY + 15
-        local hsvText = string.format("H: %d°  S: %d%%  V: %d%%", 
-            math.floor(currentH.h), 
-            math.floor(currentH.s * 100), 
-            math.floor(currentH.v * 100))
-        love.graphics.print(hsvText, previewX, hsvY)
-        
-        -- Done button
-        local doneW, doneH = 90, 28
-        local doneX, doneY = gx + gw - doneW - 16, gy + gh - doneH - 12
-        local mx, my = Viewport.getMousePosition()
-        local doneHover = mx >= doneX and mx <= doneX + doneW and my >= doneY and my <= doneY + doneH
-        Theme.drawStyledButton(doneX, doneY, doneW, doneH, "Done", doneHover, love.timer.getTime())
-        SettingsPanel._accentDone = { _rect = { x = doneX, y = doneY, w = doneW, h = doneH } }
-    else
-        SettingsPanel._accentPopup = nil
-        SettingsPanel._accentDone = nil
-        SettingsPanel._accentColorSliders = nil
-    end
+local function applySettings()
+    local newGraphicsSettings = cloneSettings(currentGraphicsSettings)
+    local newAudioSettings = cloneSettings(currentAudioSettings)
+    Settings.applySettings(newGraphicsSettings, newAudioSettings)
+    Settings.save()
+    Notifications.add(Strings.getNotification("settings_applied"), "success")
+    originalGraphicsSettings = cloneSettings(Settings.getGraphicsSettings())
+    originalAudioSettings = cloneSettings(Settings.getAudioSettings())
 end
 
 function SettingsPanel.mousepressed(raw_x, raw_y, button)
@@ -1064,102 +247,50 @@ function SettingsPanel.mousepressed(raw_x, raw_y, button)
         return true
     end
 
-    -- Use raw screen coordinates for all checks
-    local x, y = raw_x, raw_y
+    if GraphicsPanel.mousepressed(raw_x, raw_y, button) then return true end
+    if AudioPanel.mousepressed(raw_x, raw_y, button) then return true end
+    if ControlsPanel.mousepressed(raw_x, raw_y, button) then return true end
 
-    -- Also have screen coords for popups drawn in screen space
-    local screenX, screenY = Viewport.toScreen(x, y)
-
-    -- Handle overlay popups before any other UI so input doesn't leak through
-    if handleReticleGalleryClick(screenX, screenY) then return true end
-    if handleAccentGalleryClick(screenX, screenY) then return true end
-
-    -- Get geometry from the window object
     local win = SettingsPanel.window
     local panelX, panelY, w, h = win.x, win.y, win.width, win.height
     local content = win:getContentBounds()
     local contentX, contentY, contentW, contentH = content.x, content.y, content.w, content.h
-    local innerTop = contentY or panelY  -- Fallback to panelY if contentY is nil
-    local innerH = contentH or h
-    local valueX = contentX + 150
-    local dropdownW = 150
-    local itemHeight = 40
+    local innerH = contentH
 
-    -- Check if click is outside the panel
-    local isInsidePanel = x >= panelX and x <= panelX + w and y >= panelY and y <= panelY + h
-    if not isInsidePanel then
-        -- Close dropdowns if clicking outside (handled by dropdown components)
+    if raw_x < panelX or raw_x > panelX + w or raw_y < panelY or raw_y > panelY + h then
         return false
     end
 
-    -- Calculate button positions for dropdown alignment (same as in draw function)
-    local yOffsetUnscrolled = panelY + 60
-    local vsyncButtonY = yOffsetUnscrolled
-    local fpsButtonY = vsyncButtonY + itemHeight
-    local accentButtonY = fpsButtonY + itemHeight * 2  -- Skip UI scale and font scale sliders
+    if SettingsPanel._applyButton and raw_x >= SettingsPanel._applyButton._rect.x and raw_x <= SettingsPanel._applyButton._rect.x + SettingsPanel._applyButton._rect.w and raw_y >= SettingsPanel._applyButton._rect.y and raw_y <= SettingsPanel._applyButton._rect.y + SettingsPanel._applyButton._rect.h then
+        local Sound = require("src.core.sound")
+        Sound.playSFX("button_click")
+        applySettings()
+        return true
+    end
 
-    -- Handle dropdown clicks using standardized components
-    if vsyncDropdown:mousepressed(x, y, button) then return true end
-    if fpsLimitDropdown:mousepressed(x, y, button) then return true end
-    
-    -- Handle accent gallery button click
-    if SettingsPanel._accentButtonRect and x >= SettingsPanel._accentButtonRect.x and x <= SettingsPanel._accentButtonRect.x + SettingsPanel._accentButtonRect.w and y >= SettingsPanel._accentButtonRect.y and y <= SettingsPanel._accentButtonRect.y + SettingsPanel._accentButtonRect.h then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        accentGalleryOpen = not accentGalleryOpen
-        return true
-    end
-    
-    -- Handle apply and reset buttons (use content bounds like drawContent does)
-    local buttonW, buttonH = 100, 30
-    local buttonSpacing = 20
-    local totalButtonWidth = buttonW * 2 + buttonSpacing
-    local applyButtonX = contentX + (contentW / 2) - totalButtonWidth / 2
-    local resetButtonX = applyButtonX + buttonW + buttonSpacing
-    local buttonAreaY = contentY + contentH
-    local buttonY = buttonAreaY + 15
-    
-    -- Apply button
-    if x >= applyButtonX and x <= applyButtonX + buttonW and y >= buttonY and y <= buttonY + buttonH then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        local newGraphicsSettings = {}
-        for k, v in pairs(currentGraphicsSettings) do newGraphicsSettings[k] = v end
-        local newAudioSettings = {}
-        for k, v in pairs(currentAudioSettings) do newAudioSettings[k] = v end
-        Settings.applySettings(newGraphicsSettings, newAudioSettings)
-        Settings.save()
-        Notifications.add(Strings.getNotification("settings_applied"), "success")
-        originalGraphicsSettings = cloneSettings(Settings.getGraphicsSettings())
-        originalAudioSettings = cloneSettings(Settings.getAudioSettings())
-        return true
-    end
-    
-    -- Reset button
-    if x >= resetButtonX and x <= resetButtonX + buttonW and y >= buttonY and y <= buttonY + buttonH then
+    if SettingsPanel._resetButton and raw_x >= SettingsPanel._resetButton._rect.x and raw_x <= SettingsPanel._resetButton._rect.x + SettingsPanel._resetButton._rect.w and raw_y >= SettingsPanel._resetButton._rect.y and raw_y <= SettingsPanel._resetButton._rect.y + SettingsPanel._resetButton._rect.h then
         local Sound = require("src.core.sound")
         Sound.playSFX("button_click")
         SettingsPanel.resetToDefaults()
         return true
     end
 
-    -- Handle scrollbar clicking and dragging
     if contentHeight > innerH then
         local scrollbarWidth = 12
         local scrollbarX = panelX + w - scrollbarWidth - 4
-        local scrollbarY = contentY -- Use contentY, which is the true top of the content area
+        local scrollbarY = contentY
         local scrollbarH = innerH
         local thumbH = math.max(20, scrollbarH * (innerH / contentHeight))
         local trackRange = scrollbarH - thumbH
         local thumbY = scrollbarY + (trackRange > 0 and (trackRange * (scrollY / (contentHeight - innerH))) or 0)
 
-        if x >= scrollbarX and x <= scrollbarX + scrollbarWidth then
-            if y >= thumbY and y <= thumbY + thumbH then
-                draggingSlider = "scrollbar"
-                scrollDragOffset = y - thumbY
+        if raw_x >= scrollbarX and raw_x <= scrollbarX + scrollbarWidth then
+            if raw_y >= thumbY and raw_y <= thumbY + thumbH then
+                scrollDragOffset = raw_y - thumbY
+                SettingsPanel._draggingScrollbar = true
                 return true
-            elseif y >= scrollbarY and y <= scrollbarY + scrollbarH then
-                local clickY = y - scrollbarY
+            elseif raw_y >= scrollbarY and raw_y <= scrollbarY + scrollbarH then
+                local clickY = raw_y - scrollbarY
                 local frac = trackRange > 0 and (clickY / trackRange) or 0
                 local maxScroll = math.max(0, contentHeight - innerH)
                 scrollY = math.max(0, math.min(maxScroll, frac * maxScroll))
@@ -1168,131 +299,19 @@ function SettingsPanel.mousepressed(raw_x, raw_y, button)
         end
     end
 
-    -- Now handle main content (scrolled): check if click is in the visible content area
-    if x < contentX or x > contentX + contentW or y < contentY or y > contentY + contentH then
-        return false -- Not in the scrollable content area
-    end
-
-    -- Correctly calculate mouse Y position in the virtual, scrolled content space
-    -- Mouse `y` is in virtual screen space; elements are drawn translated by -scrollY,
-    -- so compare mouseY + scrollY against absolute element Y positions.
-    local scrolledY = y + scrollY
-    local sectionSpacing = 60
-
-    -- Replicate the yOffset logic from drawContent EXACTLY for perfect alignment
-    local yOffset = contentY + 10 -- Start relative to the content area's top + padding
-
-    -- === GRAPHICS SECTION ===
-    yOffset = yOffset + 30 -- "Graphics Settings" label
-
-    -- VSync Dropdown
-    -- Dropdown handles its own mousepress, so we just increment yOffset
-    yOffset = yOffset + itemHeight
-
-    -- Max FPS Dropdown
-    -- Dropdown handles its own mousepress
-    yOffset = yOffset + itemHeight
-
-    -- Show FPS Toggle
-    if SettingsPanel._showFpsToggleRect and x >= SettingsPanel._showFpsToggleRect.x and x <= SettingsPanel._showFpsToggleRect.x + SettingsPanel._showFpsToggleRect.w and y >= SettingsPanel._showFpsToggleRect.y and y <= SettingsPanel._showFpsToggleRect.y + SettingsPanel._showFpsToggleRect.h then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        currentGraphicsSettings.show_fps = not currentGraphicsSettings.show_fps
-        return true
-    end
-    yOffset = yOffset + itemHeight
-
-    -- Reticle button
-    local btnX, btnW, btnH = valueX, 140, 26
-    local btnY = yOffset - 4
-    if scrolledY >= btnY and scrolledY <= btnY + btnH and x >= btnX and x <= btnX + btnW then
-        local Sound = require("src.core.sound")
-        Sound.playSFX("button_click")
-        reticleGalleryOpen = true
-        return true
-    end
-    yOffset = yOffset + itemHeight
-
-    -- Accent Color Theme Dropdown
-    -- Dropdown handles its own mousepress
-    yOffset = yOffset + itemHeight
-
-
-    -- === AUDIO SECTION ===
-    yOffset = yOffset + 30 -- "Audio Settings" label
-
-    -- Master Volume
-    local sliderX, sliderW, sliderH = valueX, 200, 10
-    local sliderY = yOffset - 5
-    if scrolledY >= sliderY and scrolledY <= sliderY + sliderH and x >= sliderX and x <= sliderX + sliderW then
-        draggingSlider = "master_volume"
-        local pct = (x - sliderX) / sliderW -- Set initial value on click
-        currentAudioSettings.master_volume = math.max(0, math.min(1, pct))
-        return true
-    end
-    yOffset = yOffset + itemHeight
-    -- SFX Volume
-    sliderY = yOffset - 5
-    if scrolledY >= sliderY and scrolledY <= sliderY + sliderH and x >= sliderX and x <= sliderX + sliderW then
-        draggingSlider = "sfx_volume"
-        local pct = (x - sliderX) / sliderW -- Set initial value on click
-        currentAudioSettings.sfx_volume = math.max(0, math.min(1, pct))
-        return true
-    end
-    yOffset = yOffset + itemHeight
-    -- Music Volume
-    sliderY = yOffset - 5
-    if scrolledY >= sliderY and scrolledY <= sliderY + sliderH and x >= sliderX and x <= sliderX + sliderW then
-        draggingSlider = "music_volume"
-        local pct = (x - sliderX) / sliderW -- Set initial value on click
-        currentAudioSettings.music_volume = math.max(0, math.min(1, pct))
-        return true
-    end
-    yOffset = yOffset + itemHeight + sectionSpacing
-
-    -- === CONTROLS SECTION ===
-    yOffset = yOffset + 30 -- "Controls" label
-    yOffset = yOffset + 30 -- "Keybindings" label
-
-    local keybindOrder = { "toggle_inventory", "toggle_ship", "toggle_skills", "toggle_map", "hotbar_1", "hotbar_2", "hotbar_3", "hotbar_4", "hotbar_5", "hotbar_6", "hotbar_7" }
-    for _, action in ipairs(keybindOrder) do
-        local btnX, btnW, btnH = contentX + 200, 100, 24
-        local btnY = yOffset - 2
-        if scrolledY >= btnY and scrolledY <= btnY + btnH and x >= btnX and x <= btnX + btnW then
-            local Sound = require("src.core.sound")
-            Sound.playSFX("button_click")
-            bindingAction = action
-            return true
-        end
-        yOffset = yOffset + 30
-    end
-
-    return true -- Consume click inside panel
+    return false
 end
 
-function SettingsPanel.mousereleased(x, y, button)
+function SettingsPanel.mousereleased(raw_x, raw_y, button)
     if not SettingsPanel.window.visible then return false end
 
-    if SettingsPanel.window:mousereleased(x, y, button) then
+    if SettingsPanel.window:mousereleased(raw_x, raw_y, button) then
         return true
     end
 
-    draggingSlider = nil
-    
-    -- Stop color picker slider dragging
-    if accentColorPickerOpen then
-        for channel, _ in pairs(accentColorSliders) do
-            accentColorSliders[channel].dragging = false
-        end
-    end
-    
-    -- Stop accent color slider dragging
-    if draggingSlider and draggingSlider:find("accent_color_") then
-        for channel, _ in pairs(accentColorSliders) do
-            accentColorSliders[channel].dragging = false
-        end
-    end
-    
+    SettingsPanel._draggingScrollbar = false
+    AudioPanel.mousereleased(raw_x, raw_y, button)
+    GraphicsPanel.mousereleased(raw_x, raw_y, button)
     return false
 end
 
@@ -1303,8 +322,7 @@ function SettingsPanel.wheelmoved(x, y, dx, dy)
     if not win:containsPoint(x, y) then return false end
 
     local content = win:getContentBounds()
-    local innerH = content.h -- Consistent with drawContent
-
+    local innerH = content.h
     SettingsPanel.calculateContentHeight()
     local maxScroll = math.max(0, contentHeight - innerH)
 
@@ -1320,122 +338,41 @@ end
 function SettingsPanel.mousemoved(raw_x, raw_y, dx, dy)
     if not SettingsPanel.window.visible then return false end
 
-    -- Handle window dragging first
     if SettingsPanel.window:mousemoved(raw_x, raw_y, dx, dy) then
         return true
     end
 
-    local x, y = raw_x, raw_y
-    local win = SettingsPanel.window
-    local panelX, panelY, w, h = win.x, win.y, win.width, win.height
-    local content = win:getContentBounds()
-    local contentX, contentY, contentW, contentH = content.x, content.y, content.w, content.h
-    local innerH = contentH
-    local valueX = contentX + 150
-    local itemHeight = 40
+    GraphicsPanel.mousemoved(raw_x, raw_y)
+    local audioHandled = AudioPanel.mousemoved(raw_x, raw_y)
 
-    -- Reset hover states
-    for k in pairs(hoveredSlider) do hoveredSlider[k] = false end
-
-    local isInsidePanel = x >= panelX and x <= panelX + w and y >= panelY and y <= panelY + h
-
-    if isInsidePanel then
-        -- Dropdowns handle their own hover detection, no changes needed here
-        vsyncDropdown:mousemoved(x, y)
-        fpsLimitDropdown:mousemoved(x, y)
-        
-        -- Handle color picker slider dragging
-        if accentColorPickerOpen and SettingsPanel._colorPickerSliders then
-            for channel, slider in pairs(SettingsPanel._colorPickerSliders) do
-                if accentColorSliders[channel].dragging then
-                    local value = math.max(0, math.min(1, (x - slider.x) / slider.w))
-                    accentColorSliders[channel].value = value
-                    applyCustomAccentColor(accentColorSliders.r.value, accentColorSliders.g.value, accentColorSliders.b.value)
-                end
-            end
-        end
-
-        -- Check slider hovers (scrolled content)
-        -- Use the exact same logic as mousepressed to find the elements
-        if x >= contentX and x <= contentX + contentW and y >= contentY and y <= contentY + innerH then
-            -- Mouse `y` is virtual; elements are drawn translated by -scrollY.
-            -- So compare mouseY + scrollY against absolute element Y positions.
-            local scrolledY = y + scrollY
-            local sectionSpacing = 60
-            local yOffset = contentY + 10 -- Start relative to the content area's top + padding
-
-            -- === GRAPHICS SECTION ===
-            yOffset = yOffset + 30 -- "Graphics Settings" label
-            yOffset = yOffset + itemHeight -- VSync
-            yOffset = yOffset + itemHeight -- Max FPS
-            
-            yOffset = yOffset + itemHeight -- Show FPS
-            yOffset = yOffset + itemHeight -- Reticle
-            yOffset = yOffset + itemHeight -- Accent Color
-            yOffset = yOffset + itemHeight + sectionSpacing -- Helpers + spacing
-
-            -- === AUDIO SECTION ===
-            yOffset = yOffset + 30 -- "Audio Settings" label
-
-            -- Master Volume
-            local sliderY = yOffset - 5
-            if scrolledY >= sliderY and scrolledY <= sliderY + 10 and x >= valueX and x <= valueX + 200 then
-                hoveredSlider.master_volume = true
-            end
-            yOffset = yOffset + itemHeight
-            -- SFX Volume
-            sliderY = yOffset - 5
-            if scrolledY >= sliderY and scrolledY <= sliderY + 10 and x >= valueX and x <= valueX + 200 then
-                hoveredSlider.sfx_volume = true
-            end
-            yOffset = yOffset + itemHeight
-            -- Music Volume
-            sliderY = yOffset - 5
-            if scrolledY >= sliderY and scrolledY <= sliderY + 10 and x >= valueX and x <= valueX + 200 then
-                hoveredSlider.music_volume = true
-            end
-        end
-    end
-
-    if not draggingSlider then return false end
-
-    -- Handle slider dragging
-    if draggingSlider == "scrollbar" then
-        if contentHeight > innerH and innerTop then
-            local scrollbarWidth = 12
-            local scrollbarX = panelX + w - scrollbarWidth - 4
-            local scrollbarY = innerTop
-            local scrollbarH = innerH
-            local thumbH = math.max(20, scrollbarH * (innerH / contentHeight))
-            local trackRange = scrollbarH - thumbH
-
-            if trackRange > 0 and scrollbarY then
-                local newThumbY = y - scrollDragOffset
-                local frac = (newThumbY - scrollbarY) / trackRange
+    if SettingsPanel._draggingScrollbar and SettingsPanel._scrollbarTrack then
+        local content = SettingsPanel.window:getContentBounds()
+        local innerH = content.h
+        local scrollbar = SettingsPanel._scrollbarTrack
+        local thumb = SettingsPanel._scrollbarThumb
+        if scrollbar and thumb then
+            local trackRange = scrollbar.h - thumb.h
+            if trackRange > 0 then
+                local newThumbY = raw_y - scrollDragOffset
+                local frac = (newThumbY - scrollbar.y) / trackRange
                 local maxScroll = math.max(0, contentHeight - innerH)
                 scrollY = math.max(0, math.min(maxScroll, frac * maxScroll))
             end
         end
-    elseif draggingSlider == "master_volume" or draggingSlider == "sfx_volume" or draggingSlider == "music_volume" then
-        local sliderW = 200
-        local pct = (x - valueX) / sliderW
-        currentAudioSettings[draggingSlider] = math.max(0, math.min(1, pct))
+        return true
     end
-    
-    return true
+
+    return audioHandled
 end
 
 function SettingsPanel.keypressed(key)
     if not SettingsPanel.window.visible then return false end
 
-    if bindingAction then
-        Settings.setKeyBinding(bindingAction, key)
-        keymap = Settings.getKeymap()
-        bindingAction = nil
+    if ControlsPanel.keypressed(key) then
+        keymap = cloneSettings(Settings.getKeymap())
+        ControlsPanel.setKeymap(keymap, function(newMap) keymap = newMap end)
         return true
     end
-
-
 
     return false
 end
@@ -1468,11 +405,10 @@ function SettingsPanel.toggle()
 end
 
 function SettingsPanel.isBinding()
-    return bindingAction ~= nil
+    return ControlsPanel.isBinding()
 end
 
 function SettingsPanel.resetToDefaults()
-    -- Delete the settings.json file to force a complete reset
     local filename = "settings.json"
     if love.filesystem.getInfo(filename) then
         local success = love.filesystem.remove(filename)
@@ -1482,21 +418,17 @@ function SettingsPanel.resetToDefaults()
             return
         end
     end
-    
-    -- Reset to default settings
+
     local defaultGraphics = Settings.getDefaultGraphicsSettings()
     local defaultAudio = Settings.getDefaultAudioSettings()
     local defaultKeymap = Settings.getDefaultKeymap()
-    
-    -- Update current settings
+
     currentGraphicsSettings = cloneSettings(defaultGraphics)
     currentAudioSettings = cloneSettings(defaultAudio)
     keymap = cloneSettings(defaultKeymap)
-    
-    -- Apply the default settings immediately
+
     Settings.applySettings(defaultGraphics, defaultAudio)
-    
-    -- Reset keymap to defaults
+
     for action, binding in pairs(defaultKeymap) do
         if type(binding) == "table" then
             Settings.setKeyBinding(action, binding.primary, "primary")
@@ -1504,143 +436,12 @@ function SettingsPanel.resetToDefaults()
             Settings.setKeyBinding(action, binding, "primary")
         end
     end
-    
-    -- Save the reset settings
+
     Settings.save()
-    
-    -- Update dropdowns to reflect default values
-    SettingsPanel.refreshFromSettings()
-    
-    -- Update resolution dropdown
-    selectedResolutionIndex = 1
-    for i, res in ipairs(resolutions) do
-        if res.width == currentGraphicsSettings.resolution.width and res.height == currentGraphicsSettings.resolution.height then
-            selectedResolutionIndex = i
-            break
-        end
-    end
-    
-    -- Update fullscreen dropdown
-    if currentGraphicsSettings.fullscreen then
-        selectedFullscreenTypeIndex = 2
-    else
-        selectedFullscreenTypeIndex = 1
-    end
-    
-    -- Reset accent color to default
-    accentColorSliders.r.value = 0.7
-    accentColorSliders.g.value = 0.7
-    accentColorSliders.b.value = 0.7
-    applyAccentTheme("Monochrome")
-    
-    -- Show notification
+
+    updateModuleData()
+
     Notifications.add("Settings reset to defaults (saves preserved)", "success")
-end
-
-
-
--- Apply accent theme immediately for preview
-function applyAccentTheme(themeName)
-    local Theme = require("src.core.theme")
-
-    if themeName == "Cyan/Lavender" then
-        -- Single cyan theme
-        Theme.colors.accent = {0.2, 0.8, 0.9, 1.00}          -- Electric cyan (single)
-        Theme.colors.accentGold = {0.2, 0.8, 0.9, 1.00}      -- Same as accent
-        Theme.colors.accentTeal = {0.2, 0.8, 0.9, 1.00}      -- Same as accent
-        Theme.colors.accentPink = {0.2, 0.8, 0.9, 1.00}      -- Same as accent
-        Theme.colors.border = {0.5, 0.7, 0.9, 0.8}           -- Unified cyan border
-        Theme.colors.borderBright = {0.5, 0.7, 0.9, 0.8}     -- Same as border
-        Theme.colors.bg0 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.bg1 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.windowBg = {0.00, 0.00, 0.00, 1.00}     -- Pure black
-
-    elseif themeName == "Blue/Purple" then
-        -- Single blue theme
-        Theme.colors.accent = {0.4, 0.6, 1.0, 1.00}          -- Electric blue (single)
-        Theme.colors.accentGold = {0.4, 0.6, 1.0, 1.00}      -- Same as accent
-        Theme.colors.accentTeal = {0.4, 0.6, 1.0, 1.00}      -- Same as accent
-        Theme.colors.accentPink = {0.4, 0.6, 1.0, 1.00}      -- Same as accent
-        Theme.colors.border = {0.4, 0.6, 1.0, 0.8}           -- Unified blue border
-        Theme.colors.borderBright = {0.4, 0.6, 1.0, 0.8}     -- Same as border
-        Theme.colors.bg0 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.bg1 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.windowBg = {0.00, 0.00, 0.00, 1.00}     -- Pure black
-
-    elseif themeName == "Green/Emerald" then
-        -- Single green theme
-        Theme.colors.accent = {0.3, 0.9, 0.4, 1.00}          -- Emerald green (single)
-        Theme.colors.accentGold = {0.3, 0.9, 0.4, 1.00}      -- Same as accent
-        Theme.colors.accentTeal = {0.3, 0.9, 0.4, 1.00}      -- Same as accent
-        Theme.colors.accentPink = {0.3, 0.9, 0.4, 1.00}      -- Same as accent
-        Theme.colors.border = {0.3, 0.9, 0.4, 0.8}           -- Unified green border
-        Theme.colors.borderBright = {0.3, 0.9, 0.4, 0.8}     -- Same as border
-        Theme.colors.bg0 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.bg1 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.windowBg = {0.00, 0.00, 0.00, 1.00}     -- Pure black
-
-    elseif themeName == "Red/Orange" then
-        -- Single red theme
-        Theme.colors.accent = {0.9, 0.3, 0.2, 1.00}          -- Crimson red (single)
-        Theme.colors.accentGold = {0.9, 0.3, 0.2, 1.00}      -- Same as accent
-        Theme.colors.accentTeal = {0.9, 0.3, 0.2, 1.00}      -- Same as accent
-        Theme.colors.accentPink = {0.9, 0.3, 0.2, 1.00}      -- Same as accent
-        Theme.colors.border = {0.9, 0.3, 0.2, 0.8}           -- Unified red border
-        Theme.colors.borderBright = {0.9, 0.3, 0.2, 0.8}     -- Same as border
-        Theme.colors.bg0 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.bg1 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.windowBg = {0.00, 0.00, 0.00, 1.00}     -- Pure black
-
-    elseif themeName == "Monochrome" then
-        -- Single gray theme
-        Theme.colors.accent = {0.7, 0.7, 0.7, 1.00}          -- Medium gray (single)
-        Theme.colors.accentGold = {0.7, 0.7, 0.7, 1.00}      -- Same as accent
-        Theme.colors.accentTeal = {0.7, 0.7, 0.7, 1.00}      -- Same as accent
-        Theme.colors.accentPink = {0.7, 0.7, 0.7, 1.00}      -- Same as accent
-        Theme.colors.border = {0.7, 0.7, 0.7, 0.8}           -- Unified gray border
-        Theme.colors.borderBright = {0.7, 0.7, 0.7, 0.8}     -- Same as border
-        Theme.colors.bg0 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.bg1 = {0.00, 0.00, 0.00, 1.00}          -- Pure black
-        Theme.colors.windowBg = {0.00, 0.00, 0.00, 1.00}     -- Pure black
-    end
-
-    -- Update turret slot colors to match the new single-color theme
-    if themeName == "Cyan/Lavender" then
-        Theme.turretSlotColors = {
-            {0.2, 0.8, 0.9, 1.00},    -- Electric cyan
-            {0.2, 0.8, 0.9, 1.00},    -- Electric cyan
-            {0.2, 0.8, 0.9, 1.00},    -- Electric cyan
-            {0.2, 0.8, 0.9, 1.00},    -- Electric cyan
-        }
-    elseif themeName == "Blue/Purple" then
-        Theme.turretSlotColors = {
-            {0.4, 0.6, 1.0, 1.00},    -- Electric blue
-            {0.4, 0.6, 1.0, 1.00},    -- Electric blue
-            {0.4, 0.6, 1.0, 1.00},    -- Electric blue
-            {0.4, 0.6, 1.0, 1.00},    -- Electric blue
-        }
-    elseif themeName == "Green/Emerald" then
-        Theme.turretSlotColors = {
-            {0.3, 0.9, 0.4, 1.00},    -- Emerald green
-            {0.3, 0.9, 0.4, 1.00},    -- Emerald green
-            {0.3, 0.9, 0.4, 1.00},    -- Emerald green
-            {0.3, 0.9, 0.4, 1.00},    -- Emerald green
-        }
-    elseif themeName == "Red/Orange" then
-        Theme.turretSlotColors = {
-            {0.9, 0.3, 0.2, 1.00},    -- Crimson red
-            {0.9, 0.3, 0.2, 1.00},    -- Crimson red
-            {0.9, 0.3, 0.2, 1.00},    -- Crimson red
-            {0.9, 0.3, 0.2, 1.00},    -- Crimson red
-        }
-    elseif themeName == "Monochrome" then
-        Theme.turretSlotColors = {
-            {0.7, 0.7, 0.7, 1.00},    -- Medium gray
-            {0.7, 0.7, 0.7, 1.00},    -- Medium gray
-            {0.7, 0.7, 0.7, 1.00},    -- Medium gray
-            {0.7, 0.7, 0.7, 1.00},    -- Medium gray
-        }
-    end
 end
 
 return SettingsPanel


### PR DESCRIPTION
## Summary
- split the graphics, audio, and controls settings UI into dedicated modules under `src/ui/settings`
- update `SettingsPanel` to delegate drawing, input, and height calculations to the new section modules
- keep the apply/reset controls while routing gallery popups and dropdowns through their respective panels

## Testing
- not run (lua tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e3d0c3e51083228a050bdd881746d1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modularizes the settings UI by introducing dedicated Graphics/Audio/Controls panels and updating `SettingsPanel` to delegate rendering, input, overlays, and layout to them.
> 
> - **UI Settings Refactor**:
>   - `src/ui/settings_panel.lua` now delegates to section modules for draw/input/height and manages apply/reset, scrolling, and z-ordering.
>   - Adds centralized apply/reset (`applySettings`) and updates reset-to-defaults flow; refines scrollbar tracking/drag.
> - **New Modules**:
>   - `src/ui/settings/graphics_panel.lua`: VSync/FPS dropdowns, Show FPS toggle, cursor preview + reticle gallery with HSV picker, accent color/theme gallery; provides `setSettings`, `draw`, `drawForeground`, `drawOverlays`, mouse handlers, `getContentHeight`, and helpers (`refreshDropdowns`, `applyAccentTheme`, `applyCustomAccentColor`).
>   - `src/ui/settings/audio_panel.lua`: Master/SFX/Music volume sliders with hover/drag handling and content height calc.
>   - `src/ui/settings/controls_panel.lua`: Keybinding list with binding capture, button hitboxes, and change callback; exposes `setKeymap`, input handlers, and content height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c26f7dfa29d9f8c54f8616056fd95f7d16de900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->