### PR TITLE
Fix Fullscreen Flicker When Toggling Modes

### DIFF
--- a/src/core/action_map.lua
+++ b/src/core/action_map.lua
@@ -236,8 +236,36 @@ ActionMap.registerAction({
         if not love or not love.window then
             return false
         end
-        local fs = love.window.getFullscreen()
-        love.window.setFullscreen(not fs, "desktop")
+
+        local wasFullscreen = love.window.getFullscreen()
+        local toggled = love.window.setFullscreen(not wasFullscreen, "desktop")
+
+        if not toggled then
+            return false
+        end
+
+        local width, height = love.graphics.getDimensions()
+
+        -- Make sure the viewport and active UIs pick up the new backbuffer size.
+        if love.handlers and love.handlers.resize then
+            love.handlers.resize(width, height)
+        elseif love.resize then
+            love.resize(width, height)
+        end
+
+        local Settings = require("src.core.settings")
+        local graphicsSettings = Settings.getGraphicsSettings()
+        if graphicsSettings then
+            graphicsSettings.fullscreen = not wasFullscreen
+            graphicsSettings.fullscreen_type = "desktop"
+
+            if not graphicsSettings.resolution then
+                graphicsSettings.resolution = {}
+            end
+            graphicsSettings.resolution.width = width
+            graphicsSettings.resolution.height = height
+        end
+
         return true
     end,
 })

--- a/src/core/viewport.lua
+++ b/src/core/viewport.lua
@@ -79,12 +79,22 @@ function Viewport.begin()
     love.graphics.push('all')
     -- Enable stencil writes while rendering to the virtual canvas
     love.graphics.setCanvas({ canvas, stencil = true })
-    -- Do not clear here; let game decide its clear color
+    -- Clear the render target so stale pixels do not bleed through when the
+    -- output is letterboxed (which happens frequently in fullscreen mode).
+    love.graphics.clear(0, 0, 0, 0)
 end
 
 function Viewport.finish()
   love.graphics.setCanvas()
-  -- The backbuffer is no longer cleared to prevent rendering issues.
+
+  -- When the viewport is scaled down or letterboxed, clear the backbuffer so
+  -- fullscreen swaps do not flash previous frames along the unused edges.
+  local scaledW = math.floor(vw * scale + 0.5)
+  local scaledH = math.floor(vh * scale + 0.5)
+  if scaledW ~= winW or scaledH ~= winH or ox ~= 0 or oy ~= 0 then
+    love.graphics.clear(0, 0, 0, 1)
+  end
+
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.draw(canvas, ox, oy, 0, scale, scale)
   love.graphics.pop()


### PR DESCRIPTION
## Summary
- ensure the fullscreen hotkey updates viewport sizing and graphics settings after toggling
- clear the virtual canvas and backbuffer when letterboxing to avoid stale pixels in fullscreen

## Testing
- not run (Love2D not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e40eb8fee0832296d567da181af96d