### PR TITLE
Show enlarged overhead health bar for player

### DIFF
--- a/src/ui/hud/enemy_status_bars.lua
+++ b/src/ui/hud/enemy_status_bars.lua
@@ -84,11 +84,9 @@ function EnemyStatusBars.drawMiniBars(entity)
 
   -- Check if this is a player entity
   local isPlayer = entity.isPlayer or (entity.components and entity.components.player ~= nil) or entity.isRemotePlayer
-  
+
   -- For players, always show health bars
-  if isPlayer then
-    -- Always show for players
-  else
+  if not isPlayer then
     -- For enemies, show bars if recently damaged OR if enemy is low on health/shield
     local showTime = getCombatValue("ENEMY_BAR_VIS_TIME") or 2.5
     local last = entity._hudDamageTime or -1e9
@@ -114,15 +112,26 @@ function EnemyStatusBars.drawMiniBars(entity)
   local maxShield = h.maxShield or 0
 
   local radius = col.radius or 12
-  local barW = math.max(60, math.min(140, radius * 2.4))
-  local barH = 12
+
+  local barScale = 1.0
+  local barHeight = 12
+  local verticalOffset = 22
+
+  if isPlayer then
+    barScale = 1.35
+    barHeight = 16
+    verticalOffset = 30
+  end
+
+  local barW = math.max(60, math.min(140, radius * 2.4)) * barScale
+  local barH = barHeight
 
   -- Position above the ship: undo rotation so bars are screen-aligned
   local angle = (entity.components.position and entity.components.position.angle) or 0
   love.graphics.push()
   love.graphics.rotate(-angle)
 
-  local baseY = -(radius + 22)
+  local baseY = -(radius + verticalOffset)
   local x0 = -barW/2
 
   -- Combined hull + shield bar (like player) - shield overlays hull


### PR DESCRIPTION
## Summary
- always render the overhead status bar for player entities instead of only enemies
- enlarge the player's bar footprint and raise it slightly for better readability while keeping existing enemy sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e447b28290832281d54bbf968e6bbe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit afc1104d8a9dae19f26e83fbe651f248ccb52ae3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->