### PR TITLE
Introduce turret lifecycle system

### DIFF
--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -1,5 +1,5 @@
 local Util = require("src.core.util")
-local Turret = require("src.systems.turret.core")
+local TurretSystem = require("src.systems.turret.system")
 local Content = require("src.content.content")
 local Config = require("src.content.config")
 local EntityFactory = require("src.templates.entity_factory")
@@ -169,6 +169,7 @@ function Player:equipTurret(slotNum, turretId)
                     if oldId then
                         self:addItem(oldId, 1)
                     end
+                    TurretSystem.teardown(turretData.turret)
                 end
 
             local cargo = self.components.cargo
@@ -181,7 +182,7 @@ function Player:equipTurret(slotNum, turretId)
             end
 
             if turretDef then
-                local newTurret = Turret.new(self, turretDef)
+                local newTurret = TurretSystem.spawn(self, turretDef)
                 newTurret.id = turretId
                 newTurret.slot = slotNum
                 self.components.equipment.turrets[i] = {
@@ -219,6 +220,8 @@ function Player:unequipTurret(slotNum)
                     self:addItem(turretId, 1)
                 end
             end
+
+            TurretSystem.teardown(turretData.turret)
 
             -- Remove turret from slot
             self.components.equipment.turrets[i] = {
@@ -272,7 +275,7 @@ function Player:equipModule(slotNum, moduleId, turretData)
     local function instantiateTurret(def, instanceId, baseId)
         if not def then return nil end
         local turretBlueprint = Util.deepCopy(def)
-        local turretInstance = Turret.new(self, turretBlueprint)
+        local turretInstance = TurretSystem.spawn(self, turretBlueprint)
         turretInstance.id = instanceId
         turretInstance.baseId = baseId or turretBlueprint.baseId or turretBlueprint.id or instanceId
         turretInstance.slot = slotNum
@@ -380,6 +383,7 @@ function Player:unequipModule(slotNum)
                     else
                         cargo:add(moduleId, 1, Content.getTurret(baseId))
                     end
+                    TurretSystem.teardown(turretObj)
                 end
             end
 

--- a/src/game/pipeline.lua
+++ b/src/game/pipeline.lua
@@ -160,8 +160,8 @@ function Pipeline.build()
             HotbarSystem.update(ctx.dt)
         end,
         function(ctx)
-            local TurretEffects = require("src.systems.turret.effects")
-            TurretEffects.cleanupOrphanedSounds()
+            local TurretSystem = require("src.systems.turret.system")
+            TurretSystem.cleanupEffects()
         end,
         function(ctx)
             local ConstructionSystem = require("src.systems.construction")

--- a/src/managers/state_manager.lua
+++ b/src/managers/state_manager.lua
@@ -2,6 +2,7 @@ local Events = require("src.core.events")
 local Log = require("src.core.log")
 local PortfolioManager = require("src.managers.portfolio")
 local PlayerHotbar = require("src.systems.player.hotbar")
+local TurretSystem = require("src.systems.turret.system")
 
 local StateManager = {}
 
@@ -105,6 +106,9 @@ local function restoreEquipment(player, equipmentState)
   local grid = equipment.grid or {}
 
   for _, slot in ipairs(grid) do
+    if slot.type == "turret" and slot.module then
+      TurretSystem.teardown(slot.module)
+    end
     slot.id = nil
     slot.module = nil
     slot.enabled = false
@@ -114,7 +118,6 @@ local function restoreEquipment(player, equipmentState)
 
   local Content = require("src.content.content")
   local Util = require("src.core.util")
-  local Turret = require("src.systems.turret.core")
 
   for _, savedSlot in ipairs(equipmentState.grid or {}) do
     local slotIndex = savedSlot.slot and tonumber(savedSlot.slot) or nil
@@ -132,7 +135,7 @@ local function restoreEquipment(player, equipmentState)
           local turretDef = source or Content.getTurret(savedSlot.id)
           if turretDef then
             local params = Util.deepCopy(turretDef)
-            local turretInstance = Turret.new(player, params)
+            local turretInstance = TurretSystem.spawn(player, params)
             turretInstance.id = savedSlot.id
             turretInstance.slot = slotIndex
             turretInstance.baseId = (savedSlot.turret and savedSlot.turret.baseId) or params.baseId or params.id or savedSlot.id

--- a/src/systems/construction.lua
+++ b/src/systems/construction.lua
@@ -231,8 +231,8 @@ function ConstructionSystem.equipTurret(entity, turretType)
     end
     
     -- Create turret module
-    local Turret = require("src.systems.turret.core")
-    local turretModule = Turret.new(entity, {
+    local TurretSystem = require("src.systems.turret.system")
+    local turretModule = TurretSystem.spawn(entity, {
         type = turretDef.type or turretType,
         damage_range = turretDef.damage_range or {20, 20},
         damagePerSecond = turretDef.damagePerSecond or 20,

--- a/src/systems/hotbar.lua
+++ b/src/systems/hotbar.lua
@@ -181,8 +181,8 @@ function Hotbar.keypressed(key, player)
                 local idx = tonumber(item:match('^turret_slot_(%d+)$') or item:match('^module_slot_(%d+)$'))
                 if idx then
                     -- Get the turret to check its fireMode
-                    local Turret = require("src.systems.turret.core")
-                    local turret = Turret.getTurretBySlot(player, idx)
+                    local TurretSystem = require("src.systems.turret.system")
+                    local turret = TurretSystem.getTurretBySlot(player, idx)
                     if turret then
                         if turret.fireMode == "automatic" then
                             -- For automatic mode: toggle the autoFire state
@@ -213,8 +213,8 @@ function Hotbar.keyreleased(key, player)
                 local idx = tonumber(item:match('^turret_slot_(%d+)$') or item:match('^module_slot_(%d+)$'))
                 if idx then
                     -- Get the turret to check its fireMode
-                    local Turret = require("src.systems.turret.core")
-                    local turret = Turret.getTurretBySlot(player, idx)
+                    local TurretSystem = require("src.systems.turret.system")
+                    local turret = TurretSystem.getTurretBySlot(player, idx)
                     if turret and turret.fireMode == "manual" then
                         -- For manual mode: clear the firing state on key release
                         Hotbar.state.active.turret_slots = Hotbar.state.active.turret_slots or {}

--- a/src/systems/player.lua
+++ b/src/systems/player.lua
@@ -537,8 +537,8 @@ function PlayerSystem.update(dt, player, input, world, hub)
             
             -- Force stop utility beam sounds if not allowed to fire
             if not allow and (t.kind == "mining_laser" or t.kind == "salvaging_laser") then
-                local TurretEffects = require("src.systems.turret.effects")
-                TurretEffects.stopAllTurretSounds(t)
+                local TurretSystem = require("src.systems.turret.system")
+                TurretSystem.stopEffects(t)
             end
         end
     end

--- a/src/systems/turret/core.lua
+++ b/src/systems/turret/core.lua
@@ -1,18 +1,8 @@
 local Util = require("src.core.util")
-local ModifierSystem = require("src.systems.turret.modifier_system")
-local UpgradeSystem = require("src.systems.turret.upgrade_system")
 local Notifications = require("src.ui.notifications")
 local Log = require("src.core.log")
 local TurretRegistry = require("src.systems.turret.registry")
 
--- Ensure all built-in turret handlers are registered before instances are created.
-require("src.systems.turret.types.projectile")
-require("src.systems.turret.types.gun")
-require("src.systems.turret.types.missile")
-require("src.systems.turret.types.laser")
-require("src.systems.turret.types.mining_laser")
-require("src.systems.turret.types.salvaging_laser")
-require("src.systems.turret.types.plasma_torch")
 local Turret = {}
 Turret.__index = Turret
 
@@ -139,13 +129,9 @@ function Turret.new(owner, params)
     -- beams, and projectiles share the same muzzle origin.
     self.currentAimAngle = nil
 
-    self.modifierSystem = ModifierSystem.new(self, params.modifiers or {})
-    self.modifiers = self.modifierSystem:getSummaries()
-    if params.upgrades then
-        self.upgradeEntry = UpgradeSystem.attach(self, params.upgrades)
-    else
-        self.upgradeEntry = nil
-    end
+    self.modifierSystem = nil
+    self.modifiers = {}
+    self.upgradeEntry = nil
 
     -- Set default tracer colors if not specified
     if self.kind == 'gun' or self.kind == 'projectile' or not self.kind then

--- a/src/systems/turret/system.lua
+++ b/src/systems/turret/system.lua
@@ -1,0 +1,125 @@
+local TurretCore = require("src.systems.turret.core")
+local ModifierSystem = require("src.systems.turret.modifier_system")
+local UpgradeSystem = require("src.systems.turret.upgrade_system")
+local TurretEffects = require("src.systems.turret.effects")
+
+-- Ensure built-in turret handlers are registered before instances are created.
+require("src.systems.turret.types.projectile")
+require("src.systems.turret.types.gun")
+require("src.systems.turret.types.missile")
+require("src.systems.turret.types.laser")
+require("src.systems.turret.types.mining_laser")
+require("src.systems.turret.types.salvaging_laser")
+require("src.systems.turret.types.plasma_torch")
+
+local TurretSystem = {}
+
+local trackedTurrets = setmetatable({}, { __mode = "k" })
+
+local function track(turret)
+    if turret then
+        trackedTurrets[turret] = true
+    end
+end
+
+local function untrack(turret)
+    if turret then
+        trackedTurrets[turret] = nil
+    end
+end
+
+local function attachModifiers(turret, params)
+    turret.modifierSystem = ModifierSystem.new(turret, (params and params.modifiers) or {})
+    turret.modifiers = turret.modifierSystem:getSummaries()
+end
+
+local function attachUpgrades(turret, params)
+    if params and params.upgrades then
+        turret.upgradeEntry = UpgradeSystem.attach(turret, params.upgrades)
+    end
+end
+
+local function detachUpgrades(turret)
+    if turret and turret.upgradeEntry then
+        UpgradeSystem.detach(turret)
+        turret.upgradeEntry = nil
+    end
+end
+
+function TurretSystem.spawn(owner, params)
+    local turret = TurretCore.new(owner, params or {})
+    attachModifiers(turret, params)
+    attachUpgrades(turret, params)
+    track(turret)
+    return turret
+end
+
+function TurretSystem.update(turret, dt, target, locked, world)
+    if not turret then
+        return
+    end
+
+    if turret.update then
+        turret:update(dt, target, locked, world)
+    end
+end
+
+function TurretSystem.fire(turret, dt, target, locked, world)
+    if not turret then
+        return false
+    end
+
+    local handler = turret.getHandler and turret:getHandler() or nil
+    if handler and handler.fire then
+        handler.fire(turret, dt, target, locked, world)
+        return true
+    end
+
+    local previousFiring = turret.firing
+    turret.firing = true
+    TurretSystem.update(turret, dt, target, locked, world)
+    turret.firing = previousFiring
+    return true
+end
+
+function TurretSystem.stopEffects(turret)
+    if not turret then
+        return
+    end
+
+    TurretEffects.stopAllTurretSounds(turret)
+end
+
+function TurretSystem.teardown(turret)
+    if not turret then
+        return
+    end
+
+    TurretSystem.stopEffects(turret)
+    detachUpgrades(turret)
+    turret.modifierSystem = nil
+    turret.modifiers = turret.modifiers or {}
+    untrack(turret)
+end
+
+function TurretSystem.cleanupEffects()
+    TurretEffects.cleanupOrphanedSounds()
+end
+
+function TurretSystem.getTurretBySlot(owner, slot)
+    return TurretCore.getTurretBySlot(owner, slot)
+end
+
+function TurretSystem.getTurretWorldPosition(turret)
+    return TurretCore.getTurretWorldPosition(turret)
+end
+
+function TurretSystem.listActive()
+    local list = {}
+    for turret in pairs(trackedTurrets) do
+        table.insert(list, turret)
+    end
+    return list
+end
+
+return TurretSystem

--- a/src/templates/entity_factory.lua
+++ b/src/templates/entity_factory.lua
@@ -4,7 +4,7 @@ local Normalizer = require("src.content.normalizer")
 local Builder = require("src.templates.builder")
 local Log = require("src.core.log")
 local Util = require("src.core.util")
-local TurretCore = require("src.systems.turret.core")
+local TurretSystem = require("src.systems.turret.system")
 
 local function random_choice(options)
     if type(options) ~= "table" or #options == 0 then
@@ -232,7 +232,7 @@ function EntityFactory.createEnemy(shipId, x, y)
                     if turretDef then
                         local turretParams = Util.deepCopy(turretDef)
                         turretParams.fireMode = turretParams.fireMode or defaultFireMode
-                        local turretInstance = TurretCore.new(enemy, turretParams)
+                        local turretInstance = TurretSystem.spawn(enemy, turretParams)
 
                         turretInstance.fireMode = turretInstance.fireMode or defaultFireMode
                         if turretInstance.fireMode == "automatic" then

--- a/tests/turret_system_spec.lua
+++ b/tests/turret_system_spec.lua
@@ -1,0 +1,133 @@
+package.path = package.path .. ';src/?.lua;src/?/init.lua;src/?/?.lua'
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end
+}
+
+local TurretSystem = require("src.systems.turret.system")
+local UpgradeSystem = require("src.systems.turret.upgrade_system")
+local TurretRegistry = require("src.systems.turret.registry")
+
+local function assert_equal(actual, expected, message)
+    if actual ~= expected then
+        error((message or "expected values to match") .. string.format(" (expected %s, got %s)", tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assert_true(value, message)
+    if not value then
+        error(message or "expected condition to be true", 2)
+    end
+end
+
+local function create_owner()
+    return {
+        components = {
+            position = { x = 0, y = 0, angle = 0 },
+            health = { energy = 100, maxEnergy = 100 }
+        },
+        isPlayer = false
+    }
+end
+
+local tests = {}
+
+tests[#tests + 1] = {
+    name = "spawn applies modifiers",
+    fn = function()
+        local owner = create_owner()
+        local turret = TurretSystem.spawn(owner, {
+            id = "unit_test_turret",
+            type = "laser",
+            damage_range = { min = 10, max = 20 },
+            modifiers = {
+                { id = "overcharged_coils", damageMultiplier = 2.0, energyMultiplier = 1.0 }
+            }
+        })
+
+        assert_equal(math.floor(turret.damage_range.min + 0.5), 20, "modifier should scale min damage")
+        assert_equal(math.floor(turret.damage_range.max + 0.5), 40, "modifier should scale max damage")
+        assert_true(turret.modifierSystem ~= nil, "modifier system should be attached")
+        assert_true(#(turret.modifiers or {}) > 0, "modifier summaries should exist")
+
+        TurretSystem.teardown(turret)
+    end
+}
+
+tests[#tests + 1] = {
+    name = "upgrades attach and detach",
+    fn = function()
+        local owner = create_owner()
+        local turret = TurretSystem.spawn(owner, {
+            id = "upgrade_test_turret",
+            type = "laser",
+            damage_range = { min = 5, max = 5 },
+            upgrades = {
+                startLevel = 1,
+                thresholds = { 10 },
+                bonuses = {
+                    [1] = { damageMultiplier = 2 }
+                }
+            }
+        })
+
+        assert_equal(turret.damage_range.min, 10, "upgrade bonus should be applied on spawn")
+        local entry = UpgradeSystem.getEntry(turret.id)
+        assert_true(entry ~= nil, "upgrade entry should be registered")
+
+        TurretSystem.teardown(turret)
+        assert_true(UpgradeSystem.getEntry(turret.id) == nil, "upgrade entry should be removed on teardown")
+    end
+}
+
+tests[#tests + 1] = {
+    name = "fire dispatches to handler",
+    fn = function()
+        local owner = create_owner()
+
+        TurretRegistry.register("unit_test_handler", {
+            fire = function(turret, dt)
+                turret._firedWith = dt
+            end
+        })
+
+        TurretRegistry.register("unit_test_update_handler", {
+            update = function(turret, dt)
+                turret._updatedWith = dt
+            end
+        })
+
+        local turretWithFire = TurretSystem.spawn(owner, {
+            id = "handler_fire_turret",
+            type = "unit_test_handler",
+            damage_range = { min = 1, max = 1 }
+        })
+
+        local turretWithUpdate = TurretSystem.spawn(owner, {
+            id = "handler_update_turret",
+            type = "unit_test_update_handler",
+            damage_range = { min = 1, max = 1 }
+        })
+
+        TurretSystem.fire(turretWithFire, 0.25)
+        TurretSystem.fire(turretWithUpdate, 0.5)
+
+        assert_equal(turretWithFire._firedWith, 0.25, "fire handler should receive dt")
+        assert_equal(turretWithUpdate._updatedWith, 0.5, "update handler should run when fire callback missing")
+
+        TurretSystem.teardown(turretWithFire)
+        TurretSystem.teardown(turretWithUpdate)
+    end
+}
+
+local passed = 0
+for _, test in ipairs(tests) do
+    test.fn()
+    passed = passed + 1
+    print(string.format("ok - %s", test.name))
+end
+
+print(string.format("All %d turret system tests passed", passed))


### PR DESCRIPTION
## Summary
- add a turret system module that owns spawn/update/fire/cleanup responsibilities while wiring modifiers, upgrades, and effect cleanup
- update turret consumers (state restore, entity factory, construction, hotbar, player loop, pipeline) to call the new lifecycle API instead of the core module directly
- add turret system regression tests covering modifier application, upgrade attachment, and fire/update dispatch

## Testing
- lua tests/turret_system_spec.lua *(fails: lua interpreter is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68e68291a94c8322a74cca6feee64bd7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `TurretSystem` to manage turret spawn/fire/update/teardown/effects and update all call sites to use it, plus add unit tests.
> 
> - **Turret System**:
>   - Add `src/systems/turret/system.lua` providing `spawn`, `update`, `fire`, `teardown`, `stopEffects`, `cleanupEffects`, `getTurretBySlot`, and `getTurretWorldPosition`.
>   - Centralize modifier and upgrade attachment/detachment and effect cleanup.
> - **Core Adjustments**:
>   - Simplify `src/systems/turret/core.lua` by removing direct modifier/upgrade wiring and built-in type requires (moved to system).
> - **Consumers Updated**:
>   - Player/equipment: switch turret creation/removal to `TurretSystem.spawn`/`teardown` in `src/entities/player.lua`; grid handling updated accordingly.
>   - Save/restore: use `TurretSystem.spawn` and `teardown` during equipment restore/reset in `src/managers/state_manager.lua`.
>   - Hotbar: resolve turrets via `TurretSystem.getTurretBySlot` in `src/systems/hotbar.lua`.
>   - Player loop: stop utility beam sounds via `TurretSystem.stopEffects` in `src/systems/player.lua`.
>   - Pipeline: replace effects cleanup with `TurretSystem.cleanupEffects` in `src/game/pipeline.lua`.
>   - Construction and enemy factory: create turrets via `TurretSystem.spawn` in `src/systems/construction.lua` and `src/templates/entity_factory.lua`.
> - **Tests**:
>   - Add `tests/turret_system_spec.lua` covering modifier application, upgrade attach/detach, and fire/update dispatch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab85262ae4060f2fe7bfd7b3d2b1c137398f4315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->