### PR TITLE
Introduce Module Registry For Lazy Modules

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -60,6 +60,20 @@ local entity = {
 | `src/core/sound.lua` | Loads SFX/music, updates listener position, and plays events. |
 | `src/core/theme.lua` | Supplies fonts, colors, spacing tokens, and shader references for UI components. |
 
+### Module Registration & Lazy Loading
+
+`src/core/module_registry.lua` centralizes lazy-loaded dependencies so the entry point no longer needs to manage bespoke caches.
+
+- **Registration** – Startup code (currently `main.lua`) calls `ModuleRegistry.registerMany` with name/function pairs. Each
+  loader returns the module table when first invoked.
+- **Resolution** – `ModuleRegistry.get("ModuleName")` loads the dependency on first access, memoizes it, and optionally
+  reports the load duration back to the caller for profiling.
+- **Maintenance** – Use `ModuleRegistry.clear(name)` to invalidate a cached module when it should be rebuilt (e.g., forcing a
+  fresh `UIManager`). Tests or hot-reload helpers can inject doubles with `ModuleRegistry.set`.
+
+This keeps the boot script lean, provides a single location for future module wiring, and makes adding new lazily loaded systems
+as simple as appending another registration entry.
+
 ## Game Loop Flow
 
 The runtime loop is coordinated by `src/game.lua`.

--- a/src/core/module_registry.lua
+++ b/src/core/module_registry.lua
@@ -1,0 +1,82 @@
+local Log = require("src.core.log")
+
+local ModuleRegistry = {}
+
+local lazyLoaders = {}
+local loadedModules = {}
+
+local function validateName(name)
+    assert(type(name) == "string" and name ~= "", "Module name must be a non-empty string")
+    return name
+end
+
+local function validateLoader(loader)
+    assert(type(loader) == "function", "Module loader must be a function")
+    return loader
+end
+
+function ModuleRegistry.register(name, loader)
+    validateName(name)
+    validateLoader(loader)
+    lazyLoaders[name] = loader
+end
+
+function ModuleRegistry.registerMany(entries)
+    assert(type(entries) == "table", "registerMany expects a table of loader functions")
+    for name, loader in pairs(entries) do
+        ModuleRegistry.register(name, loader)
+    end
+end
+
+function ModuleRegistry.set(name, module)
+    validateName(name)
+    loadedModules[name] = module
+end
+
+function ModuleRegistry.isLoaded(name)
+    return loadedModules[name] ~= nil
+end
+
+function ModuleRegistry.clear(name)
+    if name then
+        loadedModules[name] = nil
+        return
+    end
+
+    for key in pairs(loadedModules) do
+        loadedModules[key] = nil
+    end
+end
+
+function ModuleRegistry.get(name, onLazyLoad)
+    validateName(name)
+
+    if loadedModules[name] then
+        return loadedModules[name], false
+    end
+
+    local loader = lazyLoaders[name]
+    if not loader then
+        Log.error("Attempted to resolve unknown module: " .. name)
+        return nil, false
+    end
+
+    local startTime
+    if love and love.timer and love.timer.getTime then
+        startTime = love.timer.getTime()
+    end
+
+    local module = loader()
+    loadedModules[name] = module
+
+    if startTime and onLazyLoad then
+        local loadTime = (love.timer.getTime() - startTime) * 1000
+        onLazyLoad(loadTime)
+    elseif onLazyLoad then
+        onLazyLoad(nil)
+    end
+
+    return module, true
+end
+
+return ModuleRegistry


### PR DESCRIPTION
## Summary
- replace the ad-hoc lazy module table in `main.lua` with a shared module registry helper and reuse it for cache invalidation
- add a dedicated `src/core/module_registry.lua` to centralize registration, caching, and profiling hooks for lazily loaded modules
- document the registry flow in the architecture guide so future features can hook into the system consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e6889a8b088322984659ba9c617ede

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes lazy module registration/caching with `ModuleRegistry`, updates `main.lua` to use it, and documents the flow.
> 
> - **Core**:
>   - **New `src/core/module_registry.lua`**: Provides `register`, `registerMany`, `get` (with optional profiling callback), `set`, `isLoaded`, and `clear` for centralized lazy-loading and caching.
> - **Main**:
>   - Replace ad-hoc lazy module table/cache with `ModuleRegistry.registerMany`, `ModuleRegistry.get`, and `ModuleRegistry.clear("UIManager")` in `main.lua`.
>   - Wire profiling of lazy loads via `ModuleRegistry.get` callback to populate `startupProfile.lazyLoadTimes` and log timings.
> - **Docs**:
>   - Add "Module Registration & Lazy Loading" section in `docs/ARCHITECTURE_GUIDE.md` describing registry usage and maintenance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f0763894dc31ad37e4061302cd25caff556adaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->